### PR TITLE
env: add DB TEST 형식 코드 추가#53

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1024,6 +1024,27 @@
                 "object.assign": "^4.1.0"
             }
         },
+        "babel-runtime": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+            "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+            "requires": {
+                "core-js": "^2.4.0",
+                "regenerator-runtime": "^0.11.0"
+            },
+            "dependencies": {
+                "core-js": {
+                    "version": "2.6.10",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
+                    "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+                },
+                "regenerator-runtime": {
+                    "version": "0.11.1",
+                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+                    "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+                }
+            }
+        },
         "babel-watch": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/babel-watch/-/babel-watch-7.0.0.tgz",
@@ -1470,6 +1491,26 @@
             "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
             "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
         },
+        "cli-color": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-1.4.0.tgz",
+            "integrity": "sha512-xu6RvQqqrWEo6MPR1eixqGPywhYBHRs653F9jfXB2Hx4jdM/3WxiNE1vppRmxtMIfl16SFYTpYlrnqH/HsK/2w==",
+            "requires": {
+                "ansi-regex": "^2.1.1",
+                "d": "1",
+                "es5-ext": "^0.10.46",
+                "es6-iterator": "^2.0.3",
+                "memoizee": "^0.4.14",
+                "timers-ext": "^0.1.5"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+                }
+            }
+        },
         "cli-cursor": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -1565,6 +1606,15 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "config-chain": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
+            "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
+            "requires": {
+                "ini": "^1.3.4",
+                "proto-list": "~1.2.1"
+            }
         },
         "configstore": {
             "version": "3.1.2",
@@ -1692,6 +1742,15 @@
             "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
             "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
         },
+        "d": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+            "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+            "requires": {
+                "es5-ext": "^0.10.50",
+                "type": "^1.0.1"
+            }
+        },
         "debug": {
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -1816,6 +1875,17 @@
             "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
             "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
         },
+        "editorconfig": {
+            "version": "0.15.3",
+            "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
+            "integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
+            "requires": {
+                "commander": "^2.19.0",
+                "lru-cache": "^4.1.5",
+                "semver": "^5.6.0",
+                "sigmund": "^1.0.1"
+            }
+        },
         "ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -1869,6 +1939,46 @@
                 "is-callable": "^1.1.4",
                 "is-date-object": "^1.0.1",
                 "is-symbol": "^1.0.2"
+            }
+        },
+        "es5-ext": {
+            "version": "0.10.52",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.52.tgz",
+            "integrity": "sha512-bWCbE9fbpYQY4CU6hJbJ1vSz70EClMlDgJ7BmwI+zEJhxrwjesZRPglGJlsZhu0334U3hI+gaspwksH9IGD6ag==",
+            "requires": {
+                "es6-iterator": "~2.0.3",
+                "es6-symbol": "~3.1.2",
+                "next-tick": "~1.0.0"
+            }
+        },
+        "es6-iterator": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+            "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+            "requires": {
+                "d": "1",
+                "es5-ext": "^0.10.35",
+                "es6-symbol": "^3.1.1"
+            }
+        },
+        "es6-symbol": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+            "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+            "requires": {
+                "d": "^1.0.1",
+                "ext": "^1.1.2"
+            }
+        },
+        "es6-weak-map": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+            "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+            "requires": {
+                "d": "1",
+                "es5-ext": "^0.10.46",
+                "es6-iterator": "^2.0.3",
+                "es6-symbol": "^3.1.1"
             }
         },
         "escape-html": {
@@ -2405,6 +2515,15 @@
             "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
             "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
         },
+        "event-emitter": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+            "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+            "requires": {
+                "d": "1",
+                "es5-ext": "~0.10.14"
+            }
+        },
         "execa": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
@@ -2567,6 +2686,21 @@
                 "vary": "~1.1.2"
             }
         },
+        "ext": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/ext/-/ext-1.2.0.tgz",
+            "integrity": "sha512-0ccUQK/9e3NreLFg6K6np8aPyRgwycx+oFGtfx1dSp7Wj00Ozw9r05FgBRlzjf2XBM7LAzwgLyDscRrtSU91hA==",
+            "requires": {
+                "type": "^2.0.0"
+            },
+            "dependencies": {
+                "type": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
+                    "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow=="
+                }
+            }
+        },
         "extend-shallow": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
@@ -2654,6 +2788,11 @@
                     }
                 }
             }
+        },
+        "faker": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
+            "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8="
         },
         "fast-deep-equal": {
             "version": "2.0.1",
@@ -2804,6 +2943,16 @@
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
             "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+        },
+        "fs-extra": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+            "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            }
         },
         "fs-readdir-recursive": {
             "version": "1.1.0",
@@ -3866,6 +4015,29 @@
             "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
             "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         },
+        "js-beautify": {
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.10.2.tgz",
+            "integrity": "sha512-ZtBYyNUYJIsBWERnQP0rPN9KjkrDfJcMjuVGcvXOUJrD1zmOGwhRwQ4msG+HJ+Ni/FA7+sRQEMYVzdTQDvnzvQ==",
+            "requires": {
+                "config-chain": "^1.1.12",
+                "editorconfig": "^0.15.3",
+                "glob": "^7.1.3",
+                "mkdirp": "~0.5.1",
+                "nopt": "~4.0.1"
+            },
+            "dependencies": {
+                "nopt": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+                    "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+                    "requires": {
+                        "abbrev": "1",
+                        "osenv": "^0.1.4"
+                    }
+                }
+            }
+        },
         "js-levenshtein": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
@@ -3906,6 +4078,14 @@
             "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
             "requires": {
                 "minimist": "^1.2.0"
+            }
+        },
+        "jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+            "requires": {
+                "graceful-fs": "^4.1.6"
             }
         },
         "kind-of": {
@@ -4017,6 +4197,14 @@
                 "yallist": "^2.1.2"
             }
         },
+        "lru-queue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+            "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
+            "requires": {
+                "es5-ext": "~0.10.2"
+            }
+        },
         "make-dir": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -4048,6 +4236,21 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
             "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+        },
+        "memoizee": {
+            "version": "0.4.14",
+            "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.14.tgz",
+            "integrity": "sha512-/SWFvWegAIYAO4NQMpcX+gcra0yEZu4OntmUdrBaWrJncxOqAziGFlHxc7yjKVK2uu3lpPW27P27wkR82wA8mg==",
+            "requires": {
+                "d": "1",
+                "es5-ext": "^0.10.45",
+                "es6-weak-map": "^2.0.2",
+                "event-emitter": "^0.3.5",
+                "is-promise": "^2.1",
+                "lru-queue": "0.1",
+                "next-tick": "1",
+                "timers-ext": "^0.1.5"
+            }
         },
         "merge-descriptors": {
             "version": "1.0.1",
@@ -4341,6 +4544,11 @@
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
             "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
         },
+        "next-tick": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+            "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+        },
         "nice-try": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -4353,6 +4561,22 @@
             "requires": {
                 "object.getownpropertydescriptors": "^2.0.3",
                 "semver": "^5.7.0"
+            }
+        },
+        "node-mocks-http": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/node-mocks-http/-/node-mocks-http-1.8.0.tgz",
+            "integrity": "sha512-A6YB8+sTiHZPTPf1KfwZ3sAQYSSNJTWd762IOptAmM2d6XUQ9Q1wMh+uJ7a7n2Vy6NKmODfZArqX6Rbmlg+8Fw==",
+            "requires": {
+                "accepts": "^1.3.7",
+                "depd": "^1.1.0",
+                "fresh": "^0.5.2",
+                "merge-descriptors": "^1.0.1",
+                "methods": "^1.1.2",
+                "mime": "^1.3.4",
+                "parseurl": "^1.3.3",
+                "range-parser": "^1.2.0",
+                "type-is": "^1.6.18"
             }
         },
         "node-modules-regexp": {
@@ -4577,10 +4801,24 @@
                 "word-wrap": "~1.2.3"
             }
         },
+        "os-homedir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+        },
         "os-tmpdir": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
             "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+        },
+        "osenv": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+            "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+            "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+            }
         },
         "p-finally": {
             "version": "1.0.0",
@@ -4786,6 +5024,11 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
             "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
+        },
+        "proto-list": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+            "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
         },
         "proxy-addr": {
             "version": "2.0.5",
@@ -5250,6 +5493,21 @@
                 }
             }
         },
+        "sequelize-cli": {
+            "version": "5.5.1",
+            "resolved": "https://registry.npmjs.org/sequelize-cli/-/sequelize-cli-5.5.1.tgz",
+            "integrity": "sha512-ZM4kUZvY3y14y+Rq3cYxGH7YDJz11jWHcN2p2x7rhAIemouu4CEXr5ebw30lzTBtyXV4j2kTO+nUjZOqzG7k+Q==",
+            "requires": {
+                "bluebird": "^3.5.3",
+                "cli-color": "^1.4.0",
+                "fs-extra": "^7.0.1",
+                "js-beautify": "^1.8.8",
+                "lodash": "^4.17.5",
+                "resolve": "^1.5.0",
+                "umzug": "^2.1.0",
+                "yargs": "^13.1.0"
+            }
+        },
         "sequelize-pool": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-2.3.0.tgz",
@@ -5314,6 +5572,59 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
             "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
+        },
+        "should": {
+            "version": "13.2.3",
+            "resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
+            "integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
+            "requires": {
+                "should-equal": "^2.0.0",
+                "should-format": "^3.0.3",
+                "should-type": "^1.4.0",
+                "should-type-adaptors": "^1.0.1",
+                "should-util": "^1.0.0"
+            }
+        },
+        "should-equal": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
+            "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
+            "requires": {
+                "should-type": "^1.4.0"
+            }
+        },
+        "should-format": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
+            "integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
+            "requires": {
+                "should-type": "^1.3.0",
+                "should-type-adaptors": "^1.0.1"
+            }
+        },
+        "should-type": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
+            "integrity": "sha1-B1bYzoRt/QmEOmlHcZ36DUz/XPM="
+        },
+        "should-type-adaptors": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
+            "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
+            "requires": {
+                "should-type": "^1.3.0",
+                "should-util": "^1.0.0"
+            }
+        },
+        "should-util": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
+            "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g=="
+        },
+        "sigmund": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+            "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
         },
         "signal-exit": {
             "version": "3.0.2",
@@ -5687,6 +5998,15 @@
             "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
             "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
         },
+        "timers-ext": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
+            "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
+            "requires": {
+                "es5-ext": "~0.10.46",
+                "next-tick": "1"
+            }
+        },
         "tmp": {
             "version": "0.0.33",
             "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -5761,6 +6081,11 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
             "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
         },
+        "type": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+            "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+        },
         "type-check": {
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -5781,6 +6106,15 @@
             "requires": {
                 "media-typer": "0.3.0",
                 "mime-types": "~2.1.24"
+            }
+        },
+        "umzug": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/umzug/-/umzug-2.2.0.tgz",
+            "integrity": "sha512-xZLW76ax70pND9bx3wqwb8zqkFGzZIK8dIHD9WdNy/CrNfjWcwQgQkGCuUqcuwEBvUm+g07z+qWvY+pxDmMEEw==",
+            "requires": {
+                "babel-runtime": "^6.23.0",
+                "bluebird": "^3.5.3"
             }
         },
         "undefsafe": {
@@ -5833,6 +6167,11 @@
             "requires": {
                 "crypto-random-string": "^1.0.0"
             }
+        },
+        "universalify": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
         },
         "unpipe": {
             "version": "1.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,6 +10,7 @@
         "reinstall": "rm -rf ../node_modules && yarn install",
         "test": "./node_modules/.bin/mocha ./spec --recursive",
         "test:watch": "./node_modules/.bin/mocha ./spec --recursive --watch",
+        "test:DB": "./node_modules/.bin/mocha $(find ./spec -name '*.db.spec.js') --recursive --watch",
         "build": "sh script/build.sh",
         "build:clean": "rm -rf ./build",
         "start:express": "cross-env NODE_ENV=dev ./node_modules/.bin/nodemon --config ./nodemon.json --exec babel-watch ./express/app.js",
@@ -39,8 +40,11 @@
         "mocha": "^6.2.2",
         "moment": "^2.24.0",
         "mysql2": "^2.0.0",
+        "node-mocks-http": "^1.8.0",
         "nodemon": "^1.19.4",
         "prettier": "^1.19.1",
-        "sequelize": "^5.21.2"
+        "sequelize": "^5.21.2",
+        "sequelize-cli": "^5.5.1",
+        "should": "^13.2.3"
     }
 }

--- a/backend/spec/dbtest.db.spec.js
+++ b/backend/spec/dbtest.db.spec.js
@@ -1,0 +1,27 @@
+const should = require("should");
+const httpMocks = require("node-mocks-http");
+
+const req = httpMocks.createRequest();
+const res = httpMocks.createResponse();
+const models = require("../DB/models");
+// middleware 테스트 해야 한다면 아래와 같이 mockhttp 사용
+// const test1 = await SOME_MIDDLE_WARE.index(req, res);
+
+describe("DB_TEST", () => {
+	it("dbtest1", async () => {
+		// 여기에 테스트 쿼리 문을 작성하고 그 값을 확인하면 됩니다.
+		const events = await models.Event.findOne({
+			attributes: ["code", "moderationOption", "replyOption"],
+		});
+
+		events.dataValues.should.be.eql({
+			code: "k9me",
+			moderationOption: true,
+			replyOption: false,
+		});
+	});
+	// 같은 방식으로 새로운 테스트를 시작할 수 있습니다.
+	it("dbtest2", async () => {
+		const newTest = "blahblah";
+	});
+});


### PR DESCRIPTION
DB 쿼리 테스트를 위한 명령어를 추가하고
관련 라이브러리를 설치함.
/spec 폴더에 database.db.spec.js 코드 추가하여
해당 코드를 통해 sequelize 쿼리 테스트 가능

추가한 명령어
"test:DB": "./node_modules/.bin/mocha $(find ./spec -name '*.db.spec.js')
--recursive --watch",

usage: yarn test:DB
추가설치한 라이브러리:
"should": "^13.2.3"
"node-mocks-http": "^1.8.0"