### PR TITLE
fix: DB 테스트 코드 수정

### DIFF
--- a/backend/spec/dbtest.db.spec.js
+++ b/backend/spec/dbtest.db.spec.js
@@ -2,6 +2,7 @@ const should = require("should");
 const httpMocks = require("node-mocks-http");
 const Sequelize = require("sequelize");
 const queries = require("../DB/queries/event");
+
 const req = httpMocks.createRequest();
 const res = httpMocks.createResponse();
 const models = require("../DB/models");
@@ -16,7 +17,7 @@ describe("DB_TEST", () => {
 		const compare = [];
 
 		parsedQuestion[0].Questions.forEach(elem => compare.push(elem.id));
-		compare.should.be.eql([]);
+		new Set(compare).should.be.eql(new Set([]));
 	});
 	it("get question Id from EventCode u0xn", async () => {
 		const questions = await queries.prototype.getQuestionsInEvent("u0xn");
@@ -24,7 +25,7 @@ describe("DB_TEST", () => {
 		const compare = [];
 
 		parsedQuestion[0].Questions.forEach(elem => compare.push(elem.id));
-		compare.should.be.eql([119]);
+		new Set(compare).should.be.eql(new Set([119]));
 	});
 	it("get question Id from EventCode 1cfs", async () => {
 		const questions = await queries.prototype.getQuestionsInEvent("1cfs");
@@ -32,7 +33,7 @@ describe("DB_TEST", () => {
 		const compare = [];
 
 		parsedQuestion[0].Questions.forEach(elem => compare.push(elem.id));
-		compare.should.be.eql([27, 50, 96, 279, 298]);
+		new Set(compare).should.be.eql(new Set([27, 50, 96, 279, 298]));
 	});
 	it("get question Id from EventCode dutu", async () => {
 		const questions = await queries.prototype.getQuestionsInEvent("dutu");
@@ -40,7 +41,7 @@ describe("DB_TEST", () => {
 		const compare = [];
 
 		parsedQuestion[0].Questions.forEach(elem => compare.push(elem.id));
-		compare.should.be.eql([212, 220]);
+		new Set(compare).should.be.eql(new Set([212, 220]));
 	});
 	it("get question Id from EventCode uomf", async () => {
 		const questions = await queries.prototype.getQuestionsInEvent("uomf");
@@ -48,6 +49,7 @@ describe("DB_TEST", () => {
 		const compare = [];
 
 		parsedQuestion[0].Questions.forEach(elem => compare.push(elem.id));
-		compare.should.be.eql([172, 228]);
+		new Set(compare).should.be.eql(new Set([172, 228]));
 	});
 });
+

--- a/backend/spec/dbtest.db.spec.js
+++ b/backend/spec/dbtest.db.spec.js
@@ -1,7 +1,7 @@
 const should = require("should");
 const httpMocks = require("node-mocks-http");
 const Sequelize = require("sequelize");
-const {getQuestionsInEvent} = require("../DB/queries/event.js");
+const queries = require("../DB/queries/event");
 const req = httpMocks.createRequest();
 const res = httpMocks.createResponse();
 const models = require("../DB/models");
@@ -11,7 +11,7 @@ const models = require("../DB/models");
 
 describe("DB_TEST", () => {
 	it("get question Id from EventCode k9me", async () => {
-		const questions = getQuestionsInEvent("k9me");
+		const questions = await queries.prototype.getQuestionsInEvent("k9me");
 		const parsedQuestion = JSON.parse(JSON.stringify(questions));
 		const compare = [];
 
@@ -19,7 +19,7 @@ describe("DB_TEST", () => {
 		compare.should.be.eql([]);
 	});
 	it("get question Id from EventCode u0xn", async () => {
-		const questions = getQuestionsInEvent("u0xn");
+		const questions = await queries.prototype.getQuestionsInEvent("u0xn");
 		const parsedQuestion = JSON.parse(JSON.stringify(questions));
 		const compare = [];
 
@@ -27,7 +27,7 @@ describe("DB_TEST", () => {
 		compare.should.be.eql([119]);
 	});
 	it("get question Id from EventCode 1cfs", async () => {
-		const questions = getQuestionsInEvent("1cfs");
+		const questions = await queries.prototype.getQuestionsInEvent("1cfs");
 		const parsedQuestion = JSON.parse(JSON.stringify(questions));
 		const compare = [];
 
@@ -35,7 +35,7 @@ describe("DB_TEST", () => {
 		compare.should.be.eql([27, 50, 96, 279, 298]);
 	});
 	it("get question Id from EventCode dutu", async () => {
-		const questions = getQuestionsInEvent("dutu");
+		const questions = await queries.prototype.getQuestionsInEvent("dutu");
 		const parsedQuestion = JSON.parse(JSON.stringify(questions));
 		const compare = [];
 
@@ -43,7 +43,7 @@ describe("DB_TEST", () => {
 		compare.should.be.eql([212, 220]);
 	});
 	it("get question Id from EventCode uomf", async () => {
-		const questions = getQuestionsInEvent("uomf");
+		const questions = await queries.prototype.getQuestionsInEvent("uomf");
 		const parsedQuestion = JSON.parse(JSON.stringify(questions));
 		const compare = [];
 


### PR DESCRIPTION
DB TEST 과정에서 [1,2,3] [3,2,1] 과 같은 리스트는
같은 베열임에도 불구하고 다른 배열로 인식해
테스트 코드를 통과하지 못하기때문에
set 으로 만들어 해당 문제를 해결