### PR TITLE
[김유준]W2_리뷰요청_docker_image_build_script

### DIFF
--- a/backend/docker/dockerfiles/node.Dockerfile
+++ b/backend/docker/dockerfiles/node.Dockerfile
@@ -1,0 +1,12 @@
+FROM node:10
+
+# 앱 디렉터리 생성
+WORKDIR /usr/src/app
+
+# 의존성 설치
+COPY package.json ./
+COPY yarn.lock ./
+
+COPY .env ./
+
+RUN yarn install

--- a/backend/scripts/docker_image_build.sh
+++ b/backend/scripts/docker_image_build.sh
@@ -1,0 +1,29 @@
+NODE_IMAGE_NAME=$(grep NODE_IMAGE_NAME .env | cut -d '=' -f2)
+
+cached_package_dir=./docker/cached
+cached_package_json=./docker/cached/package.json
+cached_yarn_lock=./docker/cached/yarn.lock
+
+build_node_docker_image() {
+  echo "start build docker image of node"
+  docker build -t "$NODE_IMAGE_NAME" -f ./docker/dockerfiles/node.Dockerfile .
+
+  echo "update cache package.json"
+  mkdir $cached_package_dir
+  cp ./package.json $cached_package_json
+  cp ./yarn.lock $cached_yarn_lock
+}
+
+if [[ -d $cached_package_dir ]] && [[ -f $cached_package_json ]] && [[ -f $cached_yarn_lock ]]; then
+  package_diff=$(diff $cached_package_json ./package.json)
+  package_lock_diff=$(diff $cached_yarn_lock ./yarn.lock)
+  if [[ "$package_diff" != "" ]] || [[ "$package_lock_diff" != "" ]]; then
+    echo "package cache miss"
+    echo "$package_diff"
+    echo "$package_lock_diff"
+    build_node_docker_image
+  fi
+else
+  echo "package or lock file not found"
+  build_node_docker_image
+fi


### PR DESCRIPTION
도커 이미지 빌드 관련 질문 드립니다.

# 상황 요약
* node image를 이용하여 node/express 서버를 실행하는 이미지를 만드는 node.Dockerfile 존재합니다.
* node.Dockerfile 에서는 실행에 필요한 .env와 package.json 등을 복사후 의존성 설치합니다.
* express/node 와 관련된 코드 및 의존성이 수정될 때 마다 다시 도커 이미지를 빌드 해야합니다.
* 그래서 코드의 수정의 경우 자시 빌드하는것을 막기위해 docker의 volume을 이용하여 실행 코드를 접근할 수 있도록 만들었습니다.
* 의존성의 경우 이미지를 만들때 사용된 package.json 을 따로 저장하고 빌드 스크립트 실행시 현재 packge.json과 비교하여 동일한경우 빌드 하지않도록 만들었습니다.
* 개발하는 과정에서 매번 도커 이미지를 빌드하는데는 시간이 걸리고, docker volume을 이용하여 
node_modules를 접근하면 docker를 쓰는 이유가 희석되어집니다. 


# 질문
1. 개발 단계에서 도커 없이 실행하고, 배포에서만 실행에 필요한 코드와 모듈들이 있는 이미지를 빌드하여 배포해야하는 건가요?
2. 만약 그렇다면 배포에 필요한 도커 이미지를 효율적으로 빌드 하고 테스트 할 수 있는 방법이 있나요?
