### PR TITLE
[김유준]w3_리뷰요청_사이드메뉴_버튼_및_모달

### DIFF
--- a/frontend/guest-app/src/components/CommonModal.js
+++ b/frontend/guest-app/src/components/CommonModal.js
@@ -1,0 +1,44 @@
+import React from "react";
+import Modal from "@material-ui/core/Modal";
+import makeStyles from "@material-ui/core/styles/makeStyles.js";
+import PropTypes from "prop-types";
+
+function getModalStyle() {
+	return {
+		top: `${50}%`,
+		left: `${50}%`,
+		transform: `translate(-${50}%, -${50}%)`,
+	};
+}
+
+const useStyles = makeStyles(theme => ({
+	paper: {
+		position: "absolute",
+		width: 400,
+		backgroundColor: theme.palette.background.paper,
+		boxShadow: theme.shadows[5],
+		padding: theme.spacing(2, 4, 3),
+	},
+}));
+
+function CommonModal(props) {
+	const {isOpened, onCancelClick} = props;
+	const classes = useStyles();
+	const [modalStyle] = React.useState(getModalStyle);
+
+	return (
+		<Modal open={isOpened} onClose={onCancelClick}>
+			<div style={modalStyle} className={classes.paper}>
+				{props.children}
+			</div>
+		</Modal>
+	);
+}
+
+CommonModal.propTypes = {
+	children: PropTypes.node,
+	isOpened: PropTypes.bool,
+	onCancelClick: PropTypes.func,
+};
+
+export default CommonModal;

--- a/frontend/guest-app/src/components/SideMenu/SideMenuBody.js
+++ b/frontend/guest-app/src/components/SideMenu/SideMenuBody.js
@@ -1,0 +1,84 @@
+import React from "react";
+import List from "@material-ui/core/List";
+import Divider from "@material-ui/core/Divider";
+import SideMenuItem from "./SideMenuItem.js";
+import EditProfileModal from "../Modals/EditPriofileModal/EditProfileModal.js";
+import useSideMenuStyles from "./UseSideMenuStyles.js";
+import {LogoutIcon, QuestionIcon, UserIcon} from "../FontAwesomeIcons.js";
+import useCommonModal from "../useCommonModal.js";
+import LogOutModal from "../Modals/LogoutModal.js";
+import MyQuestionModal from "../Modals/MyQuestionModal.js";
+
+function EditProfileButton() {
+	const modalState = useCommonModal();
+
+	return (
+		<div>
+			<SideMenuItem
+				icon={<UserIcon />}
+				itemText={"edit my profile"}
+				onClick={modalState.openModal}
+			/>
+			<EditProfileModal
+				isOpened={modalState.isOpened}
+				onCancelClick={modalState.closeModal}
+			/>
+		</div>
+	);
+}
+
+function MyQuestionButton() {
+	const modalState = useCommonModal();
+
+	return (
+		<div>
+			<SideMenuItem
+				icon={<QuestionIcon />}
+				itemText={"my questions"}
+				onClick={modalState.openModal}
+			/>
+			<MyQuestionModal
+				isOpened={modalState.isOpened}
+				onCancelClick={modalState.closeModal}
+			/>
+		</div>
+	);
+}
+
+function LogoutButton() {
+	const modalState = useCommonModal();
+
+	return (
+		<div>
+			<SideMenuItem
+				icon={<LogoutIcon />}
+				itemText={"logout"}
+				onClick={modalState.openModal}
+			/>
+			<LogOutModal
+				isOpened={modalState.isOpened}
+				onCancelClick={modalState.closeModal}
+			/>
+		</div>
+	);
+}
+
+function SideMenuBody(props) {
+	const classes = useSideMenuStyles;
+
+	return (
+		<div className={classes.body} role="presentation">
+			<Divider />
+			<List>
+				<EditProfileButton />
+				<MyQuestionButton />
+				<LogoutButton />
+			</List>
+			<Divider />
+
+			<EditProfileModal />
+		</div>
+	);
+}
+
+export default SideMenuBody;

--- a/frontend/guest-app/src/components/SideMenu/SideMenuItem.js
+++ b/frontend/guest-app/src/components/SideMenu/SideMenuItem.js
@@ -1,0 +1,15 @@
+import React from "react";
+import ListItem from "@material-ui/core/ListItem";
+import ListItemIcon from "@material-ui/core/ListItemIcon";
+import ListItemText from "@material-ui/core/ListItemText";
+
+function SideMenuItem({icon, itemText, onClick}) {
+	return (
+		<ListItem button key={"edit my profile"} onClick={onClick}>
+			<ListItemIcon>{icon}</ListItemIcon>
+			<ListItemText primary={itemText} />
+		</ListItem>
+	);
+}
+
+export default SideMenuItem;

--- a/frontend/guest-app/src/components/useCommonModal.js
+++ b/frontend/guest-app/src/components/useCommonModal.js
@@ -1,0 +1,22 @@
+import React from "react";
+
+const MODAL_CLOSED = false;
+const MODAL_OPENED = true;
+
+function useCommonModal(initialState = MODAL_CLOSED) {
+    const [isOpened, setIsOpened] = React.useState(initialState);
+    const openModal = () => {
+        setIsOpened(MODAL_OPENED);
+    };
+    const closeModal = () => {
+        setIsOpened(MODAL_CLOSED);
+    };
+
+    return {
+        isOpened,
+        openModal,
+        closeModal,
+    };
+}
+
+export default useCommonModal;


### PR DESCRIPTION
react의 컴포넌트 구조 설계에 대해 질문드립니다.

## 커밋된 내용
guest-app의 side menu 컴포넌트의 하위 컴포넌트인 side menu body 컴포넌트의 구현입니다. side menu body 내부에는 각 버튼별로 하위 컴포넌트로 나누어져있고, 각 하위 컴포넌트는 버튼 컴포넌트와 버튼 클릭시 열리는 모달의 컴포넌트로 구성되있습니다.

react의 재랜더링 되는 조건을 생각하면, 버튼과 버튼을 눌렀을때의 나타나는 모달 별로 컴포넌트를 나누지 않고 모든 버튼과 모달을 하나의 컴포넌트 아래에 모아놓게되면, 버튼 클릭시 상태가 변하게 되므로 클릭하지 않은 버튼과 모달까지 전부 재랜더링 되게 됩니다. 그래서 불필요한 재랜더링을 막기위해 각 버튼과 모달을 각각 하나의 컴포넌트로 구성시켰습니다.


## 질문 
1. 동일한 레벨의 컴포넌트에 대해 이런식으로 상태를 격리 시키는 방법이 react 가 추구하는 방법인가요?

