### PR TITLE
[김유준]w4_리뷰요청_socket.io_in_react_app

### DIFF
--- a/frontend/guest-app/src/App/App.js
+++ b/frontend/guest-app/src/App/App.js
@@ -1,0 +1,27 @@
+import React from "react";
+import styled from "styled-components";
+import ApolloClient from "apollo-boost";
+import {ApolloProvider} from "@apollo/react-hooks";
+import "./App.css";
+import NavBar from "../components/NavBar/NavBar.js";
+import TabGroup from "../components/TabGroup/TabGroup.js";
+
+const apolloClient = new ApolloClient({
+	uri: "http://localhost:8000/graphql",
+});
+
+const AppStyle = styled.div`
+	height: 100vh;
+	width: 100vw;
+`;
+
+export default function App() {
+	return (
+		<ApolloProvider client={apolloClient}>
+			<AppStyle>
+				<NavBar />
+				<TabGroup />
+			</AppStyle>
+		</ApolloProvider>
+	);
+}

--- a/frontend/guest-app/src/components/Question/QuestionContainer.js
+++ b/frontend/guest-app/src/components/Question/QuestionContainer.js
@@ -1,0 +1,92 @@
+import React, {useRef} from "react";
+import {useQuery} from "@apollo/react-hooks";
+import {gql} from "apollo-boost";
+import QuestionContainerHeader from "./QuestionContainerHeader.js";
+import useTabGroup from "../TabGroup/useTabGroup.js";
+import QuestionInputArea from "./QuestionInputArea/QuestionInputArea.js";
+import useQuestionCardList from "./useQuestionCardList.js";
+import QuestionCardList from "./QuestionCardList.js";
+import {socketClient, useSocket} from "../../libs/socket.io-Client-wrapper.js";
+
+const dummyEventCode = "u0xn";
+const dummyGuestId = 148;
+const dummyEventId = 2;
+const EXCHANGE_RATES = gql`
+    {
+        questions(eventCode: ${dummyEventCode}, guestId: ${dummyGuestId}) {
+            content
+            id
+            likeCount
+            isLike
+            GuestId
+            createdAt
+            guestName
+            Emojis {
+                EmojiName
+            }
+        }
+    }
+`;
+
+function QuestionContainerInner(props) {
+	const {data = undefined} = props;
+	const {questions, addQuestion} = useQuestionCardList(data);
+	const {tabIdx, selectTabIdx} = useTabGroup();
+	const userNameRef = useRef(null);
+	const questionRef = useRef(null);
+
+	useSocket("question/create", req => {
+		addQuestion(req);
+	});
+
+	const onAskQuestion = () => {
+		const userName = userNameRef.current.value;
+		const question = questionRef.current.value;
+
+		const newQuestion = {
+			userName,
+			eventId: dummyEventId,
+			guestId: dummyGuestId,
+			date: new Date(),
+			content: question,
+			isShowEditButton: true,
+			isLike: false,
+			likeCount: 0,
+		};
+
+		socketClient.emit("question/create", newQuestion);
+	};
+
+	return (
+		<>
+			<QuestionContainerHeader
+				questionNumber={questions.length}
+				tabIdx={tabIdx}
+				onSelectTab={selectTabIdx}
+			/>
+			<QuestionInputArea
+				onAskQuestion={onAskQuestion}
+				onOpen={() => {
+				}}
+				questionRef={questionRef}
+				userNameRef={userNameRef}
+			/>
+			<QuestionCardList questions={questions}/>
+		</>
+	);
+}
+
+function QuestionContainer() {
+	const {loading, error, data} = useQuery(EXCHANGE_RATES);
+
+	if (loading) return <p>Loading...</p>;
+	if (error) return <p>Error :(</p>;
+
+	return (
+		<>
+			<QuestionContainerInner data={data.questions}/>
+		</>
+	);
+}
+
+export default QuestionContainer;

--- a/frontend/guest-app/src/index.js
+++ b/frontend/guest-app/src/index.js
@@ -1,0 +1,25 @@
+import "bootstrap/dist/css/bootstrap.css";
+import React from "react";
+import ReactDOM from "react-dom";
+import "./index.css";
+import App from "./App/App.js";
+import * as serviceWorker from "./libs/serviceWorker.js";
+import {initSocketIoClientWrapper} from "./libs/socket.io-Client-wrapper.js";
+import configLoader from "./config/configLoader.js";
+
+const config = configLoader();
+
+const webSocketNameSpace = "defaultRoom";
+
+initSocketIoClientWrapper(
+	config.websocketHost,
+	config.websocketPort,
+	webSocketNameSpace,
+);
+
+ReactDOM.render(<App />, document.getElementById("root"));
+
+// If you want your app to work offline and load faster, you can change
+// unregister() to register() below. Note this comes with some pitfalls.
+// Learn more about service workers: https://bit.ly/CRA-PWA
+serviceWorker.unregister();

--- a/frontend/guest-app/src/libs/socket.io-Client-wrapper.js
+++ b/frontend/guest-app/src/libs/socket.io-Client-wrapper.js
@@ -1,0 +1,42 @@
+import io from "socket.io-client";
+
+function getSocket(URL) {
+	const socket = io(URL);
+
+	socket.on("connect", () => {
+		console.log(
+			`socket.io client connect to ${URL} as ${process.env.NODE_ENV} mode`
+		);
+	});
+
+	return socket;
+}
+
+function combineURL(host, port, nameSpace) {
+	return nameSpace ? `${host}:${port}/${nameSpace}` : `${host}:${port}`;
+}
+
+export function initSocketIoClientWrapper(
+	host = "http://127.0.0.1",
+	port = 4001,
+	nameSpace = undefined
+) {
+	const url = combineURL(host, port, nameSpace);
+
+	socketClient = getSocket(url);
+
+	emitSocketEvent = (eventName, func) => () => {
+		socketClient.emit(eventName, func());
+	};
+
+	useSocket = (eventName = "EMIT", handler = () => {
+	},) => {
+		socketClient.off(eventName);
+		socketClient.on(eventName, handler);
+	};
+}
+
+export let socketClient = () => {};
+export let emitSocketEvent = () => {};
+export let useSocket = () => {};
+

--- a/frontend/libs/socket.io-Client-wrapper.js
+++ b/frontend/libs/socket.io-Client-wrapper.js
@@ -1,0 +1,49 @@
+import io from "socket.io-client";
+import {useEffect} from "react";
+
+
+function getSocket(URL) {
+	const socket = io(URL);
+
+	socket.on("connect", () => {
+		console.log(
+			`socket.io client connect to ${URL} as ${process.env.NODE_ENV} mode`
+		);
+	});
+
+	return socket;
+}
+
+
+function combineURL(host, port, nameSpace) {
+	return nameSpace ? `${host}:${port}/${nameSpace}` : `${host}:${port}`;
+}
+
+export function initSocketIoClientWrapper(
+	host = "http://127.0.0.1",
+	port = 4001,
+	nameSpace = undefined
+) {
+	const url = combineURL(host, port, nameSpace);
+
+	socketClient = getSocket(url);
+
+	emitSocketEvent = (eventName, func) => () => {
+		socketClient.emit(eventName, func());
+	};
+
+	useSocket = (eventName = "EMIT", handler = () => {
+	}, deps = []) => {
+		useEffect(() => {
+			socketClient.on(eventName, handler);
+		}, deps);
+	};
+}
+
+export let socketClient = () => {
+};
+export let emitSocketEvent = () => {
+};
+export let useSocket = () => {
+};
+


### PR DESCRIPTION
리뷰요청한 코드는 react app 에서 socket.io를 이용하여 서버를 통신하는 기능의 일부입니다.

최초 실행시 index.js 에서 socket.io를 서버와 연결한뒤, 서버에서 "question/create"라는 이벤트를 받을떄 들어온 데이터를 QuestionContainer 컴포넌트에서 데이터를 추가하는 기능입니다. 

QuestionContainer 컴포넌트가  useSocket 커스텀 훅을 이용하여 socket handler를 등록하여 서버로 부터 이벤트 발생시 상태를 업데이트하고 재랜더링 하게되는데, 이 과정에서 socket handler가 여러번 등록 되는 문제가 있었습니다. 그래서 socket handler를 등록하기전에 이전에 등록된 handler를 제거하고 후에 등록하도록 했습니다.  제 생각에 리엑트 컴포넌트의 생명주기를 잘 이용한다면 socket handler를 한번만 등록하는것으로 처리 할 수 있을 것 같은데 , 가능 한것인가요? 



