### PR TITLE
fix: DB poll dummy data 생성방식 수정

### DIFF
--- a/backend/DB/seeders/20191113072359-demo-candidate.js
+++ b/backend/DB/seeders/20191113072359-demo-candidate.js
@@ -1,12 +1,9 @@
-
-import {makeCandadateDummy} from "../utils";
+import { makeCandadateDummy } from "../utils";
 
 module.exports = {
-	up: (queryInterface, Sequelize) => queryInterface.bulkInsert(
-		"Candidates",
-		makeCandadateDummy(),
-		{},
-	),
+	up: (queryInterface, Sequelize) =>
+		queryInterface.bulkInsert("Candidates", makeCandadateDummy(), {}),
 
-	down: (queryInterface, Sequelize) => queryInterface.bulkDelete("Candidate", null, {}),
+	down: (queryInterface, Sequelize) =>
+		queryInterface.bulkDelete("Candidates", null, {}),
 };

--- a/backend/DB/utils.js
+++ b/backend/DB/utils.js
@@ -6,6 +6,8 @@ faker.seed(1234);
 
 const EVENT_NUM = 5;
 const GUEST_NUM = 200;
+const POLL_NUM = 100;
+//const POLL_TYPE_NUM = 2; // 0: N지선다(text), 1: N지선다(date), 2: 별점매기기
 
 function makeQuestionDummy(number = 100) {
 	const bulkQuestion = [];
@@ -128,12 +130,13 @@ function makeReplyDummy(number = 200) {
 	return bulkQuestion;
 }
 
-function makePollDummy(number = 200) {
+function makePollDummy(number = POLL_NUM) {
 	const bulkPoll = [];
 
-	for (let i = 0; i < number; ++i) {
+	for (let i = 1; i <= number; ++i) {
 		const name = faker.lorem.sentence();
-		const pollType = faker.random.number(1);
+		// 0: N지선다(text), 1: N지선다(date), 2: 별점매기기
+		const pollType = i % 3;
 		const duplicateOption = faker.random.boolean();
 		const createdAt = faker.date.past(1);
 		const updatedAt = createdAt;
@@ -232,22 +235,47 @@ function makeLikeDummy(number = 100) {
 	return bulkLike;
 }
 
-function makeCandadateDummy() {
-	const dummy = require("./dummy");
+function makeCandadateDummy(number = POLL_NUM) {
+	// const dummy = require("./dummy");
 	const bulkCandidate = [];
-
-	dummy.forEach(elem => {
-		if (elem.pollType === 0) {
+	const numberOfCandidates = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11]; // index: 0 ~ 9
+	for (let index = 1; index <= POLL_NUM; index++) {
+		// 0: N지선다(text), 1: N지선다(date), 2: 별점매기기
+		if (index % 3 === 0) {
+			const LIMIT =
+				numberOfCandidates[faker.random.number({ min: 0, max: 9 })];
 			for (
 				let candadateNumber = 1;
-				candadateNumber <= 5;
+				candadateNumber <= LIMIT;
 				candadateNumber++
 			) {
 				const number = candadateNumber;
 				const content = faker.lorem.sentence();
 				const createdAt = faker.date.past(1);
 				const updatedAt = createdAt;
-				const PollId = elem.id;
+				const PollId = index;
+
+				bulkCandidate.push({
+					number,
+					content,
+					createdAt,
+					updatedAt,
+					PollId,
+				});
+			}
+		} else if (index % 3 === 1) {
+			const LIMIT =
+				numberOfCandidates[faker.random.number({ min: 0, max: 9 })];
+			for (
+				let candadateNumber = 1;
+				candadateNumber <= LIMIT;
+				candadateNumber++
+			) {
+				const number = candadateNumber;
+				const content = faker.date.between("1900-01-01", "2999-12-31");
+				const createdAt = faker.date.past(1);
+				const updatedAt = createdAt;
+				const PollId = index;
 
 				bulkCandidate.push({
 					number,
@@ -258,16 +286,17 @@ function makeCandadateDummy() {
 				});
 			}
 		} else {
+			const LIMIT = faker.random.number({ min: 2, max: 10 });
 			for (
 				let candadateNumber = 1;
-				candadateNumber <= 2;
+				candadateNumber <= LIMIT;
 				candadateNumber++
 			) {
 				const number = candadateNumber;
-				const content = candadateNumber === 1 ? "O" : "X";
+				const content = candadateNumber.toString();
 				const createdAt = faker.date.past(1);
 				const updatedAt = createdAt;
-				const PollId = elem.id;
+				const PollId = index;
 
 				bulkCandidate.push({
 					number,
@@ -278,7 +307,7 @@ function makeCandadateDummy() {
 				});
 			}
 		}
-	});
+	}
 	return bulkCandidate;
 }
 


### PR DESCRIPTION
## pollType은 3종류임 (2종류가 아님)
- 0: N지선다(text)
- 1: N지선다(date)
- 2: 별점

## 수정사항
- makePollDummy()에서 생성된 pollType과 동일하게 makeCandadateDummy()가 생성되도록 수정함
- O/X는 N지선다중 text 방식의 보기의 갯수가 2인 것임
- pollType이 2일때(별점)는 보기의 갯수가 별점 총수와 동일하도록 함
- pollType이 2일때는 추후 약간 변경될 가능성도 있음