### PR TITLE
Hotfix/yarn start script

### DIFF
--- a/backend/socket_io_server/app.js
+++ b/backend/socket_io_server/app.js
@@ -29,19 +29,6 @@ function BindSocketListener(socket, server) {
 	};
 }
 
-socketServer.on("connection", socket => {
-	const id = socket.id;
-
-	console.log(`id ${id} connected `);
-
-	const addSocketListener = BindSocketListener(socket, socketServer);
-
-	socketHandlers.forEach(({eventName, handler}) => {
-		console.log(`apply handler at ${eventName} event`);
-		addSocketListener(eventName, handler);
-	});
-});
-
 const nameSpaceServer = socketServer.of(/.*/);
 
 nameSpaceServer.on("connection", socket => {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "deploy": "sh script/deploy.sh",
     "deploy:undo": "sh script/deploy_undo.sh",
     "deploy:auto": "sh script/deploy_demon.sh",
-    "start": "sh script/start.sh"
+    "start": "sh script/start.sh",
+    "start:frontend": "sh script/start.sh",
+    "start:backend": "sh script/start.sh"
   },
   "license": "MIT",
   "dependencies": {

--- a/script/start.sh
+++ b/script/start.sh
@@ -6,4 +6,4 @@ express_server="cd ./backend & yarn start:express"
 DB_server="cd ./backend & yarn start:DB"
 yoga_server="cd ./backend & yarn start:yoga"
 
-concurrently "$guest_app"  "$main_app"  "$host_app" "$socketIO_server" "$express_server" "$DB_server" "yoga_server"
+concurrently "$guest_app"  "$main_app"  "$host_app" "$socketIO_server" "$express_server" "$DB_server" "$yoga_server"

--- a/script/start_backend.sh
+++ b/script/start_backend.sh
@@ -1,0 +1,6 @@
+socketIO_server="cd ./backend & yarn start:socket"
+express_server="cd ./backend & yarn start:express"
+DB_server="cd ./backend & yarn start:DB"
+yoga_server="cd ./backend & yarn start:yoga"
+
+concurrently "$socketIO_server" "$express_server" "$DB_server" "$yoga_server"

--- a/script/start_frontend.sh
+++ b/script/start_frontend.sh
@@ -1,0 +1,5 @@
+guest_app="cd ./frontend/guest-app & yarn start"
+main_app="cd ./frontend/main-app & yarn start"
+host_app="cd ./frontend/host-app & yarn start"
+
+concurrently "$guest_app"  "$main_app"  "$host_app"


### PR DESCRIPTION
* 프로젝트 최상위 디렉토리에서 전체 개발 서버 실행시 graphQL yoga server 실행안되는 버그 수정
* 프론트엔드 개발 서버만 실행하는 스크립트 추가
* 백엔드 개발 서버만 실행하는 스크립트 추가
* socket.io 서버의 불필요한 핸들러 제거

