### PR TITLE
Hotfix/socketio handler binder

### DIFF
--- a/backend/socket_io_server/app.js
+++ b/backend/socket_io_server/app.js
@@ -20,8 +20,8 @@ const socketServer = io(httpServer);
 function BindSocketListener(socket, server) {
 	return (eventName, handler) => {
 		socket.on(eventName, data => {
-			const emit = () => {
-				server.emit(eventName, data);
+			const emit = res => {
+				server.emit(eventName, res);
 			};
 
 			handler(data, emit);

--- a/backend/socket_io_server/app.js
+++ b/backend/socket_io_server/app.js
@@ -24,7 +24,16 @@ function BindSocketListener(socket, server) {
 				server.emit(eventName, res);
 			};
 
-			handler(data, emit);
+			try {
+				handler(data, emit, {socket, server});
+			} catch (e) {
+				console.error(
+					`while handing ${eventName} error raise,\n ${e.toString()}\n${
+						e.stack
+					}`,
+				);
+				socket.send({status: "error", error: e});
+			}
 		});
 	};
 }


### PR DESCRIPTION
# hotfix: socket.io의 BindSocketListener handler 수정


## why
* handler에서 사용되어질 context에 해당하는 socket, server가 누락됨
* handler에 대한 에러처리를 클로저에서 처리해야함
* 에러처리시 요청한 소켓에만 에러를 응답해아햠

## what i did
* emit으로 보낼 response data 인자 추가
* handler클로저에 에러 처리 추가

----

# hotfix: socket.io의 BindSocketListener emit 인자가 전달되지 않는 버그 수정

## why
인자로 들어가야할 response data가 들어가지 않고 request data가 인자 들어감

## what i did
emit으로 보낼 response data 인자 추가