### PR TITLE
hotfix:  add .envexample

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -93,3 +93,6 @@ DEV_GUEST_PAGE=http://localhost:5002/
 PROD_MAIN_PAGE=http://www.vaagle.com/main-app/
 PROD_HOST_PAGE=http://www.vaagle.com/host-app/
 PROD_GUEST_PAGE=http://www.vaagle.com/guest-app/
+
+REDIS_DEV_PORT=6379
+REDIS_DEV_HOST=127.0.0.1


### PR DESCRIPTION
redis env setting이 누락되어있어서 DB start 및 migration이 안되던 문제가 발생
임시적으로 .env redis 세팅부분을 .envexample에 추가하여 문제를 해결하도록 함.