### PR TITLE
Feature/host-app 상단고정 및 검열 column 접힘 구현

### DIFF
--- a/backend/graphQL/model/question/question.graphql
+++ b/backend/graphQL/model/question/question.graphql
@@ -2,7 +2,6 @@ type Question {
 	id: ID!
 	EventId: ID!
 	GuestId: ID!
-	QuestionId: ID
 	createdAt: String!
 	content: String!
 	state: String!

--- a/frontend/host-app/src/App/App.js
+++ b/frontend/host-app/src/App/App.js
@@ -10,6 +10,8 @@ import {HostProvider} from "../libs/hostContext";
 import {getEventsByHost} from "../libs/gql";
 import EmptyContent from "../components/EmptyContent";
 import {socketClient} from "../libs/socket.io-Client-wrapper";
+import SkeletonContent from "../components/SkeletonContent";
+import SkeletonTitle from "../components/SkeletionTitle";
 
 
 function App() {
@@ -17,8 +19,12 @@ function App() {
 	const {data, loading, error} = useQuery(getEventsByHost());
 	const [events, setEvents] = useState("");
 	let eventNum = 0;
+
 	if (loading) {
-		return (<Skeleton variant="rect" width={1500} height={104} />);
+		return (<>
+			<SkeletonTitle/>
+			<SkeletonContent/>
+		</>);
 	} else if (error) {
 		return <p>error-page...</p>;
 	} else {
@@ -29,9 +35,11 @@ function App() {
 			);
 		}
 		const hostInfo = data.init.host;
+
 		eventNum = events.length;
 		if (eventNum) {
 			const eventId = events[0].id;
+
 			socketClient.emit("event/initOption", eventId); // dummy Event Id:2
 		}
 

--- a/frontend/host-app/src/components/Column.js
+++ b/frontend/host-app/src/components/Column.js
@@ -5,8 +5,10 @@ import {ColumnStyle} from "./ComponentsStyle";
 import {filterStared} from "../libs/utils";
 
 function Column({type, state, stateHandler, data, dataHandler, handleStar}) {
+	const staredData = filterStared(true, data);
+
 	return (
-		<ColumnStyle>
+		<ColumnStyle height={`${100 + (staredData.questions.length * 10)}%` }>
 			<Title
 				type={type}
 				state={state}
@@ -16,15 +18,17 @@ function Column({type, state, stateHandler, data, dataHandler, handleStar}) {
 			/>
 			<QuestionContainer
 				type={type}
-				datas={filterStared(true, data)}
+				datas={staredData}
 				dataHandler={dataHandler}
 				handleStar={handleStar}
+				containerType={"focus"}
 			/>
 			<QuestionContainer
 				type={type}
 				datas={filterStared(false, data)}
 				dataHandler={dataHandler}
 				handleStar={handleStar}
+				containerType={"unFocus"}
 			/>
 		</ColumnStyle>
 	);

--- a/frontend/host-app/src/components/Column.js
+++ b/frontend/host-app/src/components/Column.js
@@ -2,6 +2,7 @@ import React from "react";
 import Title from "./Title";
 import QuestionContainer from "./Questions/QuestionContainer";
 import {ColumnStyle} from "./ComponentsStyle";
+import {filterStared} from "../libs/utils";
 
 function Column({type, state, stateHandler, data, dataHandler, handleStar}) {
 	return (
@@ -13,7 +14,18 @@ function Column({type, state, stateHandler, data, dataHandler, handleStar}) {
 				data={data}
 				dataHandler={dataHandler}
 			/>
-			<QuestionContainer type={type} datas={data} dataHandler={dataHandler} handleStar={handleStar}/>
+			<QuestionContainer
+				type={type}
+				datas={filterStared(true, data)}
+				dataHandler={dataHandler}
+				handleStar={handleStar}
+			/>
+			<QuestionContainer
+				type={type}
+				datas={filterStared(false, data)}
+				dataHandler={dataHandler}
+				handleStar={handleStar}
+			/>
 		</ColumnStyle>
 	);
 }

--- a/frontend/host-app/src/components/Column.js
+++ b/frontend/host-app/src/components/Column.js
@@ -2,14 +2,15 @@ import React, {useState} from "react";
 import Title from "./Title";
 import QuestionContainer from "./Questions/QuestionContainer";
 import ColumnFooter from "./ColumnFooter";
-import {ColumnStyle} from "./ComponentsStyle";
+import {QuestionStyle, ModerationStyle} from "./ComponentsStyle";
 import {filterStared} from "../libs/utils";
 
 function Column({type, state, stateHandler, data, dataHandler, handleStar}) {
-	const [heightWeight,setHeightWeight] = useState(0);
+	const [heightWeight, setHeightWeight] = useState(0);
+	const ColumnStyle = ((type === "moderation") ? ModerationStyle : QuestionStyle);
 
 	return (
-		<ColumnStyle height={`${100 +(heightWeight * 50)}%`}>
+		<ColumnStyle height={`${100 + (heightWeight * 50)}%`} state={state}>
 			<Title
 				type={type}
 				state={state}

--- a/frontend/host-app/src/components/Column.js
+++ b/frontend/host-app/src/components/Column.js
@@ -1,14 +1,15 @@
-import React from "react";
+import React, {useState} from "react";
 import Title from "./Title";
 import QuestionContainer from "./Questions/QuestionContainer";
+import ColumnFooter from "./ColumnFooter";
 import {ColumnStyle} from "./ComponentsStyle";
 import {filterStared} from "../libs/utils";
 
 function Column({type, state, stateHandler, data, dataHandler, handleStar}) {
-	const staredData = filterStared(true, data);
+	const [heightWeight,setHeightWeight] = useState(0);
 
 	return (
-		<ColumnStyle height={`${100 + (staredData.questions.length * 10)}%` }>
+		<ColumnStyle height={`${100 +(heightWeight * 50)}%`}>
 			<Title
 				type={type}
 				state={state}
@@ -18,7 +19,7 @@ function Column({type, state, stateHandler, data, dataHandler, handleStar}) {
 			/>
 			<QuestionContainer
 				type={type}
-				datas={staredData}
+				datas={filterStared(true, data)}
 				dataHandler={dataHandler}
 				handleStar={handleStar}
 				containerType={"focus"}
@@ -30,6 +31,7 @@ function Column({type, state, stateHandler, data, dataHandler, handleStar}) {
 				handleStar={handleStar}
 				containerType={"unFocus"}
 			/>
+			<ColumnFooter/>
 		</ColumnStyle>
 	);
 }

--- a/frontend/host-app/src/components/Column.js
+++ b/frontend/host-app/src/components/Column.js
@@ -31,7 +31,7 @@ function Column({type, state, stateHandler, data, dataHandler, handleStar}) {
 				handleStar={handleStar}
 				containerType={"unFocus"}
 			/>
-			<ColumnFooter/>
+			<ColumnFooter data={heightWeight} handler={setHeightWeight}/>
 		</ColumnStyle>
 	);
 }

--- a/frontend/host-app/src/components/ColumnFooter.js
+++ b/frontend/host-app/src/components/ColumnFooter.js
@@ -1,0 +1,23 @@
+import React from "react";
+import {Icon} from "@material-ui/core";
+import {TitleBox, FooterStyle} from "./ComponentsStyle";
+import useStyles from "./Questions/useStyles";
+
+function ColumnFooter({titleName,data}) {
+	const classes = useStyles();
+
+	return (
+		<FooterStyle>
+			<TitleBox>
+				<Icon className={classes.footerButton}>
+					remove_circle
+				</Icon>
+				<Icon className={classes.footerButton}>
+					add_circle
+				</Icon>
+			</TitleBox>
+		</FooterStyle>
+	);
+}
+
+export default ColumnFooter;

--- a/frontend/host-app/src/components/ColumnFooter.js
+++ b/frontend/host-app/src/components/ColumnFooter.js
@@ -3,17 +3,19 @@ import {Icon} from "@material-ui/core";
 import {TitleBox, FooterStyle} from "./ComponentsStyle";
 import useStyles from "./Questions/useStyles";
 
-function ColumnFooter({titleName,data}) {
+function ColumnFooter({data,handler}) {
 	const classes = useStyles();
+	const increaseHeight = () => handler(data + 1);
+	const decreaseHeight = () => ((data > 0) && handler(data - 1));
 
 	return (
 		<FooterStyle>
 			<TitleBox>
-				<Icon className={classes.footerButton}>
-					remove_circle
+				<Icon className={classes.footerButton} onClick={() => { decreaseHeight(); }}>
+					remove
 				</Icon>
-				<Icon className={classes.footerButton}>
-					add_circle
+				<Icon className={classes.footerButton} onClick={() => { increaseHeight(); }}>
+					add
 				</Icon>
 			</TitleBox>
 		</FooterStyle>

--- a/frontend/host-app/src/components/ComponentsStyle.js
+++ b/frontend/host-app/src/components/ComponentsStyle.js
@@ -61,9 +61,15 @@ const ColumnStyle = styled.div`
 	border: 1px solid #e9ecef;
 	height: ${props => props.height || "100%" };
 	box-sizing: border-box;
+	margin-bottom: 1rem;
 	& + & {
 		margin-left: 8px;
 	}
 `;
 
-export {TitleStyle, TitleBox, RightSide, EmptyContentBox, EmptyContentDiv, ContentStyle, ColumnStyle}
+const FooterStyle = styled.div`
+	width: 90%;
+	margin-top: auto;
+`;
+
+export {TitleStyle, TitleBox, RightSide, EmptyContentBox, EmptyContentDiv, ContentStyle, ColumnStyle,FooterStyle}

--- a/frontend/host-app/src/components/ComponentsStyle.js
+++ b/frontend/host-app/src/components/ComponentsStyle.js
@@ -54,7 +54,6 @@ const ColumnStyle = styled.div`
 	flex-direction: column;
 	flex: 1;
 	min-width: 20rem;
-	overflow: auto;
 	justify-content: flex-start;
 	align-items: center;
 	border-radius: 8px;

--- a/frontend/host-app/src/components/ComponentsStyle.js
+++ b/frontend/host-app/src/components/ComponentsStyle.js
@@ -43,7 +43,7 @@ const ContentStyle = styled.div`
 	flex: 1;
 	overflow: auto;
 	justify-content: left;
-	align-items: center;
+	align-items: flex-start;
 	padding: 4px 8px;
 	overflow-x: auto;
 	flex-wrap: nowrap;
@@ -59,7 +59,7 @@ const ColumnStyle = styled.div`
 	border-radius: 8px;
 	background-color: #f1f3f5;
 	border: 1px solid #e9ecef;
-	height: 100%;
+	height: ${props => props.height || "100%" };
 	box-sizing: border-box;
 	& + & {
 		margin-left: 8px;

--- a/frontend/host-app/src/components/ComponentsStyle.js
+++ b/frontend/host-app/src/components/ComponentsStyle.js
@@ -1,4 +1,26 @@
-import styled from "styled-components";
+import styled ,{keyframes} from "styled-components";
+
+const Open = keyframes`
+	0% { 
+		min-width: 8rem; 
+		height: 15%;
+	}
+	100% { 
+		min-width: 20rem;
+		height: 100%;
+	}
+`;
+
+const Close = keyframes`
+	0% { 
+		min-width: 20rem;
+		height: 100%;	
+	}
+	100% { 
+		min-width: 8rem; 
+		height: 15%;
+	}
+`;
 
 const TitleBox = styled.div`
 	display: flex;
@@ -49,17 +71,50 @@ const ContentStyle = styled.div`
 	flex-wrap: nowrap;
 `;
 
-const ColumnStyle = styled.div`
+const QuestionStyle = styled.div`
 	display: flex;
 	flex-direction: column;
 	flex: 1;
-	min-width: 20rem;
 	justify-content: flex-start;
 	align-items: center;
 	border-radius: 8px;
 	background-color: #f1f3f5;
 	border: 1px solid #e9ecef;
+	min-width: 20rem;
 	height: ${props => props.height || "100%" };
+	box-sizing: border-box;
+	margin-left: 8px;
+`;
+
+const ModerationStyle = styled.div`
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+	animation: ${props => ((props.state) ? Open : Close)};
+    animation-duration: 2s;
+    animation-fill-mode: forwards;
+	justify-content: flex-start;
+	align-items: center;
+	border-radius: 8px;
+	background-color: #f1f3f5;
+	border: 1px solid #e9ecef;
+	min-width: ${props => ((props.state) ? "20rem" : "8rem")};
+	height: ${props => props.height || "100%" };
+	box-sizing: border-box;
+	& + & {
+		margin-left: 8px;
+	}
+`;
+
+const SkeletonColumnStyle = styled.div`
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+	justify-content: flex-start;
+	align-items: center;
+	border-radius: 8px;
+	min-width: "20rem";
+	height:"100%";
 	box-sizing: border-box;
 	& + & {
 		margin-left: 8px;
@@ -78,6 +133,8 @@ export {
 	EmptyContentBox,
 	EmptyContentDiv,
 	ContentStyle,
-	ColumnStyle,
+	QuestionStyle,
 	FooterStyle,
+	SkeletonColumnStyle,
+	ModerationStyle,
 };

--- a/frontend/host-app/src/components/ComponentsStyle.js
+++ b/frontend/host-app/src/components/ComponentsStyle.js
@@ -61,7 +61,6 @@ const ColumnStyle = styled.div`
 	border: 1px solid #e9ecef;
 	height: ${props => props.height || "100%" };
 	box-sizing: border-box;
-	margin-bottom: 1rem;
 	& + & {
 		margin-left: 8px;
 	}
@@ -72,4 +71,13 @@ const FooterStyle = styled.div`
 	margin-top: auto;
 `;
 
-export {TitleStyle, TitleBox, RightSide, EmptyContentBox, EmptyContentDiv, ContentStyle, ColumnStyle,FooterStyle}
+export {
+	TitleStyle,
+	TitleBox,
+	RightSide,
+	EmptyContentBox,
+	EmptyContentDiv,
+	ContentStyle,
+	ColumnStyle,
+	FooterStyle,
+};

--- a/frontend/host-app/src/components/Questions/LiveQuestionCard.js
+++ b/frontend/host-app/src/components/Questions/LiveQuestionCard.js
@@ -31,7 +31,6 @@ function LiveQuestionCard(props) {
 								onClick={() => props.handleStar(props.id)}>
 								stars
 							</Icon>
-							<Icon className={classes.upwardButton}>publish</Icon>
 							<Icon
 								className={classes.approveButton}
 								onClick={() => props.dataHandler(props.id, props.type, "completeQuestion")}>

--- a/frontend/host-app/src/components/Questions/QuestionContainer.js
+++ b/frontend/host-app/src/components/Questions/QuestionContainer.js
@@ -1,22 +1,19 @@
 import React from "react";
-import styled from "styled-components";
 import ModerationQuestionCard from "./ModerationQuestionCard.js";
 import LiveQuestionCard from "./LiveQuestionCard";
 import CompleteQuestionCard from "./CompleteQuestionCard";
 import PollApollo from "../Poll/PollApollo.js";
 import {filterQuestion, filterReplies} from "../../libs/utils";
-
-const QuestionDiv = styled.div`
-	width: 100%;
-	overflow: auto;
-`;
+import {FocusedDiv, UnFocusedDiv} from "./QuestionStyle";
 
 const compareByCreateAt = (a, b) =>
 	a.createdAt < b.createdAt ? 1 : a.createdAt > b.createdAt ? -1 : 0;
 const compareByLikeCount = (a, b) =>
 	a.likeCount < b.likeCount ? 1 : a.likeCount > b.likeCount ? -1 : 0;
 
-function QuestionContainer({datas, type, dataHandler, handleStar}) {
+function QuestionContainer({datas, type, dataHandler, handleStar, containerType}) {
+	const QuestionDiv = containerType === "focus" ? FocusedDiv : UnFocusedDiv;
+
 	return (
 		<QuestionDiv>
 			{type === "moderation" &&
@@ -66,7 +63,7 @@ function QuestionContainer({datas, type, dataHandler, handleStar}) {
 						replies={filterReplies(question.id, datas).questions}
 					/>
 				))}
-			{type === "poll" && <PollApollo />}
+			{(type === "poll" && containerType !== "focus") && <PollApollo />}
 		</QuestionDiv>
 	);
 }

--- a/frontend/host-app/src/components/Questions/QuestionContainer.js
+++ b/frontend/host-app/src/components/Questions/QuestionContainer.js
@@ -8,6 +8,7 @@ import {filterQuestion, filterReplies} from "../../libs/utils";
 
 const QuestionDiv = styled.div`
 	width: 100%;
+	overflow: auto;
 `;
 
 const compareByCreateAt = (a, b) =>

--- a/frontend/host-app/src/components/Questions/QuestionReducer.js
+++ b/frontend/host-app/src/components/Questions/QuestionReducer.js
@@ -1,6 +1,9 @@
 const QuestionsReducer = (state, action) => {
 	const actionTable = {
-		addNewQuestion: () => ({questions: [...state.questions, action.data]}),
+		addNewQuestion: () => {
+			console.log([...state.questions, action.data]);
+			return ({questions: [...state.questions, action.data]});
+		},
 		toggleStar: () => {
 			const newData = state.questions.map(e => (e.id === action.data.id ? action.data : e));
 

--- a/frontend/host-app/src/components/Questions/QuestionStyle.js
+++ b/frontend/host-app/src/components/Questions/QuestionStyle.js
@@ -49,6 +49,15 @@ const ReplyBody = styled.div`
 	margin: 0.5rem 1rem;
 `;
 
+const FocusedDiv = styled.div`
+	width: 100%;
+`;
+
+const UnFocusedDiv = styled.div`
+	width: 100%;
+	overflow: auto;
+`;
+
 export {
 	QuestionHeader,
 	QuestionMeta,
@@ -59,4 +68,6 @@ export {
 	ReplyContainer,
 	ReplyBody,
 	ReplyInfo,
+	FocusedDiv,
+	UnFocusedDiv,
 };

--- a/frontend/host-app/src/components/Questions/useStyles.js
+++ b/frontend/host-app/src/components/Questions/useStyles.js
@@ -38,8 +38,8 @@ const useStyles = makeStyles(theme => ({
 	},
 	footerButton: {
 		color: "rgb(121,121,121)",
-		margin: " 0.2rem",
-		transform: "scale(0.7)",
+		margin: " 0.1rem",
+		transform: "scale(0.6)",
 		"&:hover": {
 			color: "#ef0046",
 		},

--- a/frontend/host-app/src/components/Questions/useStyles.js
+++ b/frontend/host-app/src/components/Questions/useStyles.js
@@ -36,6 +36,14 @@ const useStyles = makeStyles(theme => ({
 			color: "#ef0046",
 		},
 	},
+	footerButton: {
+		color: "rgb(121,121,121)",
+		margin: " 0.2rem",
+		transform: "scale(0.7)",
+		"&:hover": {
+			color: "#ef0046",
+		},
+	},
 	thumbUpButton: {
 		color: "#7f7f7f",
 		transform: "scale(0.7)",

--- a/frontend/host-app/src/components/SkeletionTitle.js
+++ b/frontend/host-app/src/components/SkeletionTitle.js
@@ -1,0 +1,12 @@
+import {Skeleton} from "@material-ui/lab";
+import React from "react";
+
+function SkeletonTitle() {
+	return (<>
+		<Skeleton variant="rect" width={1500} height={56} />
+		<Skeleton variant="text" width={550} height={6} />
+		<Skeleton variant="text" width={550} height={6} />
+	</>);
+}
+
+export default SkeletonTitle;

--- a/frontend/host-app/src/components/SkeletonContent.js
+++ b/frontend/host-app/src/components/SkeletonContent.js
@@ -1,25 +1,25 @@
 import {Skeleton} from "@material-ui/lab";
 import React from "react";
-import {ContentStyle, ColumnStyle} from "./ComponentsStyle";
+import {ContentStyle, SkeletonColumnStyle} from "./ComponentsStyle";
 
 function SkeletonContent() {
 	return (
 		<ContentStyle>
-			<ColumnStyle>
+			<SkeletonColumnStyle>
 				<Skeleton variant="rect" width={318} height={817} />
-			</ColumnStyle>
-			<ColumnStyle>
+			</SkeletonColumnStyle>
+			<SkeletonColumnStyle>
 				<Skeleton variant="rect" width={318} height={817} />
-			</ColumnStyle>
-			<ColumnStyle>
+			</SkeletonColumnStyle>
+			<SkeletonColumnStyle>
 				<Skeleton variant="rect" width={318} height={817} />
-			</ColumnStyle>
-			<ColumnStyle>
+			</SkeletonColumnStyle>
+			<SkeletonColumnStyle>
 				<Skeleton variant="rect" width={318} height={817} />
-			</ColumnStyle>
-			<ColumnStyle>
+			</SkeletonColumnStyle>
+			<SkeletonColumnStyle>
 				<Skeleton variant="rect" width={318} height={817} />
-			</ColumnStyle>
+			</SkeletonColumnStyle>
 		</ContentStyle>
 	);
 }

--- a/frontend/host-app/src/components/SwitchTitle.js
+++ b/frontend/host-app/src/components/SwitchTitle.js
@@ -1,6 +1,5 @@
 import React, {useContext} from "react";
 import Switch from "@material-ui/core/Switch";
-import styled from "styled-components";
 import Badge from "@material-ui/core/Badge";
 import {makeStyles} from "@material-ui/core";
 import {socketClient, useSocket} from "../libs/socket.io-Client-wrapper";

--- a/frontend/host-app/src/libs/utils.js
+++ b/frontend/host-app/src/libs/utils.js
@@ -18,6 +18,13 @@ export function filterQuestion(option, data){
 	return {questions: data.questions.filter(e => e.state === option && e.QuestionId === null)};
 }
 
+export function filterStared(option, data){
+	return {questions: data.questions.filter(e => {
+		if (e.QuestionId !== null) return true;
+		return e.isStared === option
+	})};
+}
+
 export function filterReplies(id, data){
 	return {questions: data.questions.filter(e => e.QuestionId === id )};
 }

--- a/frontend/host-app/src/libs/utils.js
+++ b/frontend/host-app/src/libs/utils.js
@@ -6,10 +6,10 @@ export function makeNewData(req) {
 		createdAt: req.createdAt,
 		guestName: req.guestName,
 		id: req.id,
-		isLike: req.didILike,
 		likeCount: req.likeCount,
 		state: req.status,
-		QuestionId: req.QuestionId
+		QuestionId: req.QuestionId,
+		isStared: false,
 	};
 	return newData;
 }


### PR DESCRIPTION
### 구현 사항
- `star` 버튼 누르면 상단 고정되도록 변경
- `star` 기능을 여러개 사용하면 시야가 너무 좁아져  `+ -` 버튼을 추가하여 `column` 사이즈 변경 구현(임시)

### 수정사항
- `host-app` 스크롤시 column 제목까지 같이 스크롤되던것 수정
- `검열` 기능 사용하지 않을 때 column 이 접히도록 변경

### 고민해볼 사항
- `sli.do` 의 경우 시야를 위해 `star` 가 하나만 가능(즉 상단 고정 되는게 하나)
- 시야 확보를 위해 `sli.do` 와 같이 `star` 를 하나만 사용할지, 아니면 다른 방법이 있는지 고민해 보아야 할듯.