### PR TITLE
feature/host-app 상단 고정 , mac CSS 깨짐 해결

### DIFF
--- a/backend/DB/queries/question.js
+++ b/backend/DB/queries/question.js
@@ -1,6 +1,7 @@
 import Sequelize from "sequelize";
 import models from "../models";
 
+const sequelize = models.sequelize;
 const Op = Sequelize.Op;
 const Question = models.Question;
 
@@ -51,6 +52,27 @@ export async function updateQuestionById({id, content, state, isStared}) {
 		},
 		{where: {id}},
 	);
+}
+
+export async function updateIsStared(from, to) {
+	const transaction = await sequelize.transaction();
+
+	try {
+		if (from) {
+			await Question.update({isStared: to.isStared},
+				{where: {id: from.id}},
+				{transaction},
+			);
+		}
+		await Question.update({isStared: to.isStared},
+			{where: {id: to.id}},
+			{transaction},
+		);
+		await transaction.commit();
+	} catch (err) {
+		if (transaction) await transaction.rollback();
+		console.log("Transaction rollback", err);
+	}
 }
 
 export async function updateEveryState(from, {state}) {

--- a/backend/socket_io_server/socketHandler/Question/toggleStar.socketHandler.js
+++ b/backend/socket_io_server/socketHandler/Question/toggleStar.socketHandler.js
@@ -1,13 +1,11 @@
-import {updateQuestionById} from "../../../DB/queries/question";
+import {updateIsStared} from "../../../DB/queries/question";
 
 const toggleStarSocketHandler = async (data, emit) => {
 	try {
 		const from = data.from[0];
 		const to = data.to[0];
 
-		if (from) { await updateQuestionById({id: from.id, isStared: from.isStared}); }
-		await updateQuestionById({id: to.id, isStared: to.isStared});
-
+		await updateIsStared(from, to);
 		emit(to);
 	} catch (e) {
 		console.log(e);

--- a/backend/socket_io_server/socketHandler/Question/toggleStar.socketHandler.js
+++ b/backend/socket_io_server/socketHandler/Question/toggleStar.socketHandler.js
@@ -1,8 +1,11 @@
+import {updateQuestionById} from "../../../DB/queries/question";
 
 const toggleStarSocketHandler = async (data, emit) => {
 	try {
-		console.log(data);
+		const id = data.id;
+		const isStared = data.isStared;
 
+		await updateQuestionById({id, isStared});
 		emit(data);
 	} catch (e) {
 		console.log(e);

--- a/backend/socket_io_server/socketHandler/Question/toggleStar.socketHandler.js
+++ b/backend/socket_io_server/socketHandler/Question/toggleStar.socketHandler.js
@@ -2,11 +2,13 @@ import {updateQuestionById} from "../../../DB/queries/question";
 
 const toggleStarSocketHandler = async (data, emit) => {
 	try {
-		const id = data.id;
-		const isStared = data.isStared;
+		const from = data.from[0];
+		const to = data.to[0];
 
-		await updateQuestionById({id, isStared});
-		emit(data);
+		if (from) { await updateQuestionById({id: from.id, isStared: from.isStared}); }
+		await updateQuestionById({id: to.id, isStared: to.isStared});
+
+		emit(to);
 	} catch (e) {
 		console.log(e);
 		emit({status: "error", e});

--- a/frontend/host-app/src/components/ColumnFooter.js
+++ b/frontend/host-app/src/components/ColumnFooter.js
@@ -1,6 +1,6 @@
 import React from "react";
 import {Icon} from "@material-ui/core";
-import {TitleBox, FooterStyle} from "./ComponentsStyle";
+import {FooterBox, FooterStyle} from "./ComponentsStyle";
 import useStyles from "./Questions/useStyles";
 
 function ColumnFooter({data, handler}) {
@@ -10,14 +10,14 @@ function ColumnFooter({data, handler}) {
 
 	return (
 		<FooterStyle>
-			<TitleBox>
+			<FooterBox>
 				<Icon className={classes.footerButton} onClick={() => { decreaseHeight(); }}>
 					remove
 				</Icon>
 				<Icon className={classes.footerButton} onClick={() => { increaseHeight(); }}>
 					add
 				</Icon>
-			</TitleBox>
+			</FooterBox>
 		</FooterStyle>
 	);
 }

--- a/frontend/host-app/src/components/ComponentsStyle.js
+++ b/frontend/host-app/src/components/ComponentsStyle.js
@@ -3,7 +3,7 @@ import styled, {keyframes} from "styled-components";
 const Open = keyframes`
 	0% { 
 		min-width: 8rem; 
-		height: 15%;
+		height: 13%;
 	}
 	100% { 
 		min-width: 20rem;
@@ -18,7 +18,7 @@ const Close = keyframes`
 	}
 	100% { 
 		min-width: 8rem; 
-		height: 15%;
+		height: 13%;
 	}
 `;
 
@@ -27,6 +27,15 @@ const TitleBox = styled.div`
 	align-items: center;
 	width: 100%;
 	justify-content: space-around;
+	min-height: 2.5rem;
+`;
+
+const FooterBox = styled.div`
+	display: flex;
+	align-items: center;
+	width: 100%;
+	justify-content: space-around;
+	height: 1rem;
 `;
 
 const TitleStyle = styled.div`
@@ -100,6 +109,7 @@ const ModerationStyle = styled.div`
 	border: 1px solid #e9ecef;
 	min-width: ${props => ((props.state) ? "20rem" : "8rem")};
 	height: ${props => props.height || "100%"};
+	min-height: 2.5rem;
 	box-sizing: border-box;
 	& + & {
 		margin-left: 8px;
@@ -137,4 +147,5 @@ export {
 	FooterStyle,
 	SkeletonColumnStyle,
 	ModerationStyle,
+	FooterBox,
 };

--- a/frontend/host-app/src/components/ComponentsStyle.js
+++ b/frontend/host-app/src/components/ComponentsStyle.js
@@ -91,7 +91,7 @@ const ModerationStyle = styled.div`
 	flex-direction: column;
 	flex: 1;
 	animation: ${props => ((props.state) ? Open : Close)};
-    animation-duration: 2s;
+    animation-duration: 0.2s;
     animation-fill-mode: forwards;
 	justify-content: flex-start;
 	align-items: center;

--- a/frontend/host-app/src/components/Content.js
+++ b/frontend/host-app/src/components/Content.js
@@ -35,6 +35,7 @@ function Inner({data, event, option}) {
 
 	const handleQuestionDatas = (id, from, to) => socketClient.emit("question/move", {id, from, to});
 	const handleStar = id => {
+		/*
 		questions.questions.some(e => {
 			if (e.id === id) {
 				e.isStared = !e.isStared;
@@ -42,7 +43,14 @@ function Inner({data, event, option}) {
 				return true;
 			}
 			return false;
-		});
+		}); // {from: [id,바뀐토글] , to:[id,바뀐토글] }*/
+		const re = questions.questions.reduce((acc, e) => {
+			if (e.isStared) { acc.from.push({id: e.id, isStared: !e.isStared}); }
+			if (e.id === id) { acc.to.push({id: e.id, isStared: !e.isStared}); }
+			return acc;
+		}, {from: [], to: []});
+
+		socketClient.emit("question/toggleStar", re);
 	};
 
 	return (

--- a/frontend/host-app/src/components/Questions/CompleteQuestionCard.js
+++ b/frontend/host-app/src/components/Questions/CompleteQuestionCard.js
@@ -10,6 +10,7 @@ import useStyles from "./useStyles";
 import QuestionMenu from "./QuestionMenu";
 import ThumbUpButton from "./ThumbUpButton";
 import Replies from "./Replies";
+import Tooltip from "@material-ui/core/Tooltip";
 
 function CompleteQuestionCard(props) {
 	const classes = useStyles();
@@ -26,11 +27,13 @@ function CompleteQuestionCard(props) {
 							<QuestionDate {...props} />
 						</QuestionInfo>
 						<QuestionButtons>
-							<Icon
-								className={classes.restoreButton}
-								onClick={() => props.dataHandler(props.id, props.type, "active")}>
-								restore
-							</Icon>
+							<Tooltip title="질문 되살리기">
+								<Icon
+									className={classes.restoreButton}
+									onClick={() => props.dataHandler(props.id, props.type, "active")}>
+									restore
+								</Icon>
+							</Tooltip>
 							<QuestionMenu id={props.id} type={props.type} handler={props.dataHandler}/>
 						</QuestionButtons>
 					</QuestionMeta>

--- a/frontend/host-app/src/components/Questions/CompleteQuestionCard.js
+++ b/frontend/host-app/src/components/Questions/CompleteQuestionCard.js
@@ -26,6 +26,11 @@ function CompleteQuestionCard(props) {
 							<QuestionDate {...props} />
 						</QuestionInfo>
 						<QuestionButtons>
+							<Icon
+								className={classes.restoreButton}
+								onClick={() => {}}>
+								restore
+							</Icon>
 							<QuestionMenu id={props.id} type={props.type} handler={props.dataHandler}/>
 						</QuestionButtons>
 					</QuestionMeta>

--- a/frontend/host-app/src/components/Questions/CompleteQuestionCard.js
+++ b/frontend/host-app/src/components/Questions/CompleteQuestionCard.js
@@ -28,7 +28,7 @@ function CompleteQuestionCard(props) {
 						<QuestionButtons>
 							<Icon
 								className={classes.restoreButton}
-								onClick={() => {}}>
+								onClick={() => props.dataHandler(props.id, props.type, "active")}>
 								restore
 							</Icon>
 							<QuestionMenu id={props.id} type={props.type} handler={props.dataHandler}/>

--- a/frontend/host-app/src/components/Questions/LiveQuestionCard.js
+++ b/frontend/host-app/src/components/Questions/LiveQuestionCard.js
@@ -10,6 +10,7 @@ import useStyles from "./useStyles";
 import QuestionMenu from "./QuestionMenu";
 import ThumbUpButton from "./ThumbUpButton";
 import Replies from "./Replies";
+import Tooltip from "@material-ui/core/Tooltip";
 
 function LiveQuestionCard(props) {
 	const classes = useStyles();
@@ -26,16 +27,20 @@ function LiveQuestionCard(props) {
 							<QuestionDate {...props} />
 						</QuestionInfo>
 						<QuestionButtons>
-							<Icon
-								className={classes.starButton}
-								onClick={() => props.handleStar(props.id)}>
-								stars
-							</Icon>
-							<Icon
-								className={classes.approveButton}
-								onClick={() => props.dataHandler(props.id, props.type, "completeQuestion")}>
-								check_circle_outline
-							</Icon>
+							<Tooltip title="상단 고정">
+								<Icon
+									className={classes.starButton}
+									onClick={() => props.handleStar(props.id)}>
+									stars
+								</Icon>
+							</Tooltip>
+							<Tooltip title="답변 완료">
+								<Icon
+									className={classes.approveButton}
+									onClick={() => props.dataHandler(props.id, props.type, "completeQuestion")}>
+									check_circle_outline
+								</Icon>
+							</Tooltip>
 							<QuestionMenu id={props.id} type={props.type} handler={props.dataHandler}/>
 						</QuestionButtons>
 					</QuestionMeta>

--- a/frontend/host-app/src/components/Questions/ModerationQuestionCard.js
+++ b/frontend/host-app/src/components/Questions/ModerationQuestionCard.js
@@ -1,6 +1,7 @@
 import React from "react";
 import Card from "@material-ui/core/Card";
 import {CardContent, Icon} from "@material-ui/core";
+import Tooltip from "@material-ui/core/Tooltip";
 import UserAvata from "./UserAvata.js";
 import {QuestionHeader, QuestionBody, QuestionInfo, QuestionMeta, QuestionButtons} from "./QuestionStyle";
 import QuestionDate from "./QuestionDate";
@@ -21,21 +22,20 @@ function ModerationQuestionCard(props) {
 							<QuestionDate {...props} />
 						</QuestionInfo>
 						<QuestionButtons>
-							<Icon
-								className={classes.starButton}
-								onClick={() => props.handleStar(props.id)}>
-								stars
-							</Icon>
-							<Icon
-								className={classes.approveButton}
-								onClick={() => props.dataHandler(props.id, props.type, "active")}>
-								check_circle_outline
-							</Icon>
-							<Icon
-								className={classes.cancelButton}
-								onClick={() => props.dataHandler(props.id, props.type, "deleted")}>
-								highlight_off
-							</Icon>
+							<Tooltip title="승인">
+								<Icon
+									className={classes.approveButton}
+									onClick={() => props.dataHandler(props.id, props.type, "active")}>
+									check_circle_outline
+								</Icon>
+							</Tooltip>
+							<Tooltip title="거절">
+								<Icon
+									className={classes.cancelButton}
+									onClick={() => props.dataHandler(props.id, props.type, "deleted")}>
+									highlight_off
+								</Icon>
+							</Tooltip>
 						</QuestionButtons>
 					</QuestionMeta>
 				</QuestionHeader>

--- a/frontend/host-app/src/components/Questions/QuestionMenu.js
+++ b/frontend/host-app/src/components/Questions/QuestionMenu.js
@@ -3,6 +3,7 @@ import Menu from "@material-ui/core/Menu";
 import MenuItem from "@material-ui/core/MenuItem";
 import {Icon} from "@material-ui/core";
 import useStyles from "./useStyles";
+import Tooltip from "@material-ui/core/Tooltip";
 
 const ITEM_HEIGHT = 48;
 
@@ -26,7 +27,9 @@ export default function QuestionMenu({id, type, handler}) {
 
 	return (
 		<>
-			<Icon className={classes.moreButton} onClick={handleClick}>more_vert</Icon>
+			<Tooltip title="메뉴">
+				<Icon className={classes.moreButton} onClick={handleClick}>more_vert</Icon>
+			</Tooltip>
 			<Menu
 				id="long-menu"
 				anchorEl={anchorEl}

--- a/frontend/host-app/src/components/Questions/QuestionMenu.js
+++ b/frontend/host-app/src/components/Questions/QuestionMenu.js
@@ -1,9 +1,9 @@
 import React from "react";
+import Tooltip from "@material-ui/core/Tooltip";
 import Menu from "@material-ui/core/Menu";
 import MenuItem from "@material-ui/core/MenuItem";
 import {Icon} from "@material-ui/core";
 import useStyles from "./useStyles";
-import Tooltip from "@material-ui/core/Tooltip";
 
 const ITEM_HEIGHT = 48;
 

--- a/frontend/host-app/src/components/Questions/QuestionMenu.js
+++ b/frontend/host-app/src/components/Questions/QuestionMenu.js
@@ -40,9 +40,6 @@ export default function QuestionMenu({id, type, handler}) {
 					},
 				}}
 			>
-				<MenuItem key={"편집"} onClick={handleClose}>
-					{"편집"}
-				</MenuItem>
 				<MenuItem key={"삭제"} onClick={() => { handleDelete(); } }>
 					{"삭제"}
 				</MenuItem>

--- a/frontend/host-app/src/components/Questions/QuestionReducer.js
+++ b/frontend/host-app/src/components/Questions/QuestionReducer.js
@@ -5,7 +5,10 @@ const QuestionsReducer = (state, action) => {
 			return ({questions: [...state.questions, action.data]});
 		},
 		toggleStar: () => {
-			const newData = state.questions.map(e => (e.id === action.data.id ? action.data : e));
+			const newData = state.questions.map(e => {
+				(e.id !== action.data.id) ? (e.isStared = false) : (e.isStared = action.data.isStared);
+				return e;
+			});
 
 			return {questions: [...newData]};
 		},

--- a/frontend/host-app/src/components/Questions/useStyles.js
+++ b/frontend/host-app/src/components/Questions/useStyles.js
@@ -15,7 +15,7 @@ const useStyles = makeStyles(theme => ({
 			color: "#EF0046",
 		},
 	},
-	upwardButton: {
+	restoreButton: {
 		color: "#5a7ec4",
 		marginLeft: "0.25rem",
 		"&:hover": {

--- a/frontend/host-app/src/components/RadioTitle.js
+++ b/frontend/host-app/src/components/RadioTitle.js
@@ -1,6 +1,7 @@
 import React from "react";
 import Radio from "@material-ui/core/Radio";
 import Badge from "@material-ui/core/Badge";
+import Tooltip from '@material-ui/core/Tooltip';
 import {makeStyles} from "@material-ui/core/styles";
 import {Icon} from "@material-ui/core";
 import {TitleStyle, TitleBox, RightSide} from "./ComponentsStyle";
@@ -34,12 +35,14 @@ function RadioTitle({titleName, state, stateHandler, idx, data, dataHandler, typ
 					checked={state[idx] === SELECTED}
 					onClick={stateHandler.bind(this, idx)}
 				/>
-				<Icon
-					className={classes.icon}
-					onClick={() => dataHandler("all", "active", "completeQuestion")}
-				>
-					delete_outlined_icon
-				</Icon>
+				<Tooltip title="모든 질문 완료">
+					<Icon
+						className={classes.icon}
+						onClick={() => dataHandler("all", "active", "completeQuestion")}
+					>
+						launch
+					</Icon>
+				</Tooltip>
 			</RightSide>
 		</TitleBox>
 	) : (


### PR DESCRIPTION
###  구현 사항
- `host-app` 상단 고정 기능 DB 와 연동
- `host-app` 상단 고정 기능 에서 중복 고정이 안되도록 변경(한번에 하나의 질문만 고정되도록)
- `mac` `safari` 환경에서 컴포넌트가 깨지던 현상 개선
- 'completeQuestion' 기능 구현, 그 역인 `restore` 기능도 구현

### minor-fix
- 버튼 컴포넌트에 툴팁 추가
- 버튼 메뉴에서 `편집` 기능 삭제
