### PR TITLE
hotfix: backend build 스크립트 수정

### DIFF
--- a/backend/script/build.sh
+++ b/backend/script/build.sh
@@ -8,6 +8,7 @@ cp -r ./DB ./build/DB
 cp -r ./express ./build/express
 cp -r ./socket_io_server ./build/socket_io_server
 cp -r ./graphQL ./build/graphQL
+cp -r ./libs ./build/libs
 cp .env ./build/.env
 
 source_dir="./build"


### PR DESCRIPTION
* libs의 하위 디렉토리의 파일을 babel 빌드에서 누락됨