### PR TITLE
fix: 상단고정 guest-app 에서 중복해서 나타는 현상 제거

### DIFF
--- a/frontend/guest-app/src/components/Question/QuestionsRepliesReducer.js
+++ b/frontend/guest-app/src/components/Question/QuestionsRepliesReducer.js
@@ -172,7 +172,7 @@ const onToggleStarQuestion = (state, data) => {
 	const newState = _.cloneDeep(state);
 
 	newState.map(e => {
-		if (e.id === data.id) { e.isStared = data.isStared; }
+		if (e.id === data.id) { e.isStared = data.isStared; } else { e.isStared = false; }
 		return e;
 	});
 


### PR DESCRIPTION
guest-app 에서 isStared 를 처리할 때 이전에 켜져있던
isStared 를 false 로 변경하지 않아 중복해서 상단고정
되던 문제해결