### PR TITLE
hotfix: guest app에 새로운 로그인이 안되는 버그 수정

### DIFF
--- a/backend/express/routes/guest.js
+++ b/backend/express/routes/guest.js
@@ -22,7 +22,7 @@ router.get("/:path", guestAuthenticate(), async (req, res, next) => {
 	try {
 		const path = req.params.path;
 		const eventId = await convertPathToEvent(path);
-		const guest = await createGuest("Anonymous", eventId);
+		const guest = await createGuest(eventId);
 		const accessToken = generateAccessToken(guest.guestSid, "guest");
 		res.cookie(cookieName, accessToken, {
 			expires: getTokenExpired(24),


### PR DESCRIPTION
# 원인
guest-app 로그인시 createGuest DB query 할때 잘못된 인자를 넘겨줌