### PR TITLE
Refactoring/express and db query api

### DIFF
--- a/backend/DB/logger.js
+++ b/backend/DB/logger.js
@@ -1,0 +1,5 @@
+import getLogger from "../libs/logger.js";
+
+const logger = getLogger("mySQL_Query");
+
+export default logger;

--- a/backend/DB/queries/candidate.js
+++ b/backend/DB/queries/candidate.js
@@ -1,17 +1,14 @@
+import Sequelize from "sequelize";
 import models from "../models";
-
-const Sequelize = require("sequelize");
 
 const Op = Sequelize.Op;
 
 export async function getCandidatesByPollId(pollIdList) {
-	const result = await models.Candidate.findAll({
+	return models.Candidate.findAll({
 		where: {
 			PollId: {
 				[Op.or]: pollIdList,
 			},
 		},
 	});
-
-	return result;
 }

--- a/backend/DB/queries/event.js
+++ b/backend/DB/queries/event.js
@@ -16,140 +16,57 @@ export async function createEvent({
 	return models.Event.findOrCreate({
 		where: {eventCode},
 		defaults: {
+			eventName,
+			HostId,
 			moderationOption,
 			replyOption,
 			startAt,
 			endAt,
-			HostId,
-			eventName,
 		},
 	});
 }
 
-export async function updateEventById(
+export async function updateEventById({
 	id,
-	{eventName, moderationOption, replyOption, startAt, endAt}
-) {
+	eventName,
+	moderationOption,
+	replyOption,
+	startAt,
+	endAt,
+}) {
 	return models.Event.update(
 		{eventName, moderationOption, replyOption, startAt, endAt},
-		{where: {id}}
+		{where: {id}},
 	);
 }
 
 export async function getEventsByHostId(hostId) {
-	const events = await models.Event.findAll({
+	return models.Event.findAll({
 		where: {HostId: hostId},
 	});
-
-	return events;
 }
 
 export async function getEventByEventCode(eventCode) {
-	const event = await models.Event.findOne({
+	return models.Event.findOne({
 		where: {
 			eventCode,
 		},
 	});
-
-	return event;
 }
 
 export async function getEventById(EventId) {
-	const event = await models.Event.findOne({
+	return models.Event.findOne({
 		where: {
 			id: EventId,
 		},
 	});
-
-	return event;
 }
 
 export async function getEventOptionByEventId(id) {
-	const event = await models.Event.findOne({
+	return models.Event.findOne({
 		where: {
 			id,
 		},
 		attributes: ["moderationOption", "replyOption"],
 	});
-
-	return event;
-}
-
-export async function getQuestionLikeCount(EventId = 2, limit, offset) {
-	return models.Question.findAll({
-		attributes: ["id", [models.sequelize.fn("count", "*"), "likeCount"]],
-		where: {EventId, QuestionId: null},
-		include: [
-			{
-				model: models.Like,
-				attributes: [],
-			},
-		],
-		group: "id",
-		offset,
-		limit,
-	});
-}
-
-export async function getQuestionsByEventCodeAndGuestId(
-	eventCode,
-	guestId,
-	limit = 70,
-	offset
-) {
-	// const event = await models.Event.findOne({where: {eventCode}});
-	// const EventId = event.dataValues.id
-	const EventId = 2;
-
-	return models.Question.findAll({
-		where: {EventId, QuestionId: null},
-		include: [
-			{
-				model: models.Like,
-			},
-			{
-				model: models.Emoji,
-			},
-			{
-				model: models.Guest,
-			},
-		],
-		offset,
-		limit,
-	});
-}
-
-export async function raw_getQuestionsByEventCodeAndGuestId(
-	eventCode,
-	guestId,
-	limit = 100,
-	offset = 0
-) {
-	// const event = await models.Event.findOne({where: {eventCode}});
-	// const EventId = event.dataValues.id
-	const EventId = 2;
-
-	const query = `
-	select *, Emojis.name, Emojis.GuestId 
-	from Questions 
-		inner join Emojis on Questions.id = Emojis.QuestionId
-	where EventId = :EventId and Questions.QuestionId is null
--- 	order by Emojis.QuestionId DESC
-	
--- 	limit :limit offset :offset
-	
--- 	group by Emojis.QuestionId
-`;
-	// console.log(event.dataValues.id)
-	const [questions] = await models.sequelize.query(query, {
-		replacements: {
-			EventId,
-			limit,
-			offset,
-			type: Sequelize.QueryTypes.SELECT,
-			raw: true,
-		},
-	});
-
-	return questions;
 }

--- a/backend/DB/queries/guest.js
+++ b/backend/DB/queries/guest.js
@@ -4,11 +4,12 @@ import getRandomGuestName from "../dummy/RandomGuestName";
 
 const Guest = models.Guest;
 
-async function findGuestBySid(guestSid) {
-	const guest = await Guest.findOne({where: {guestSid}});
-	const result = guest ? guest.dataValues : false;
+async function getGuestByGuestSid(guestSid) {
+	return Guest.findOne({where: {guestSid}});
+}
 
-	return result;
+async function isExistGuest(guestSid) {
+	return !!(await getGuestByGuestSid(guestSid));
 }
 
 async function createGuest(eventId) {
@@ -19,9 +20,7 @@ async function createGuest(eventId) {
 		isAnonymous: 1,
 	});
 
-	const result = guest ? guest.dataValues : false;
-
-	return result;
+	return guest.get({plain: true});
 }
 
 async function getGuestById(id) {
@@ -31,10 +30,7 @@ async function getGuestById(id) {
 }
 
 async function updateGuestById({id, name, isAnonymous, company, email}) {
-	return Guest.update(
-		{name, company, isAnonymous, email},
-		{where: {id}},
-	);
+	return Guest.update({name, company, isAnonymous, email}, {where: {id}});
 }
 
 async function getGuestByEventId(EventId) {
@@ -46,5 +42,6 @@ export {
 	getGuestById,
 	updateGuestById,
 	getGuestByEventId,
-	findGuestBySid,
+	isExistGuest,
+	getGuestByGuestSid
 };

--- a/backend/DB/queries/hashtag.js
+++ b/backend/DB/queries/hashtag.js
@@ -5,7 +5,7 @@ const Hashtag = models.Hashtag;
 export async function createHashtag({name, EventId}) {
 	return Hashtag.create(
 		{name, EventId},
-		{default: {updateAt: new Date(), createAt: new Date()}}
+		{default: {updateAt: new Date(), createAt: new Date()}},
 	);
 }
 

--- a/backend/DB/queries/host.js
+++ b/backend/DB/queries/host.js
@@ -1,23 +1,20 @@
 import models from "../models";
 
-async function findHostByAuthId(oAuthid) {
-	const host = await models.Host.findOne({where: {oauthId: oAuthid}});
-	const result = host ? host.dataValues : false;
+// todo: 더 좋은 이름
+export async function findHostByAuthId(oauthId) {
+	const host = await models.Host.findOne({where: {oauthId}});
 
-	return result;
+	return host ? host.dataValues : false;
 }
 
-async function createHost(oAuthid, name, image, email) {
+export async function createHost(oauthId, name, image, email) {
 	const host = await models.Host.create({
-		oauthId: oAuthid,
+		oauthId,
 		name,
 		email,
 		image,
-		emailFeedBack: 0,
+		emailFeedBack: false,
 	});
-	const result = host ? host.dataValues : false;
 
-	return result;
+	return host ? host.dataValues : false;
 }
-
-export {createHost, findHostByAuthId};

--- a/backend/DB/queries/poll.js
+++ b/backend/DB/queries/poll.js
@@ -1,46 +1,40 @@
 import models from "../models";
+import logger from "../logger.js";
 
 const sequelize = models.sequelize;
 const Poll = models.Poll;
 const Candidate = models.Candidate;
 
-export async function openPoll(pollId) {
-	const now = new Date();
-	const result = await models.Poll.update(
+export async function openPoll(id) {
+	// result should be == [1], 1개의 row가 성공했다는 의미
+	return Poll.update(
 		{
 			state: "running",
-			pollDate: now,
+			pollDate: new Date(),
 		},
 		{
-			where: {id: pollId},
-		}
+			where: {id},
+		},
 	);
-
-	// result should be == [1], 1개의 row가 성공했다는 의미
-	return result;
 }
 
-export async function closePoll(pollId) {
-	const result = await models.Poll.update(
+export async function closePoll(id) {
+	// result should be == [1], 1개의 row가 성공했다는 의미
+	return Poll.update(
 		{
 			state: "closed",
 		},
 		{
-			where: {id: pollId},
-		}
+			where: {id},
+		},
 	);
-
-	// result should be == [1], 1개의 row가 성공했다는 의미
-	return result;
 }
 
-export async function getPollsByEventId(eventId) {
-	const result = await models.Poll.findAll({
-		where: {EventId: eventId},
+export async function getPollsByEventId(EventId) {
+	return Poll.findAll({
+		where: {EventId},
 		order: [["id", "DESC"]],
 	});
-
-	return result;
 }
 
 const makeCandidateRows = (id, pollType, candidates) => {
@@ -55,6 +49,7 @@ const makeCandidateRows = (id, pollType, candidates) => {
 		});
 		i++;
 	}
+
 	return nItems;
 };
 
@@ -64,7 +59,7 @@ export async function createPoll(
 	pollType,
 	selectionType,
 	allowDuplication,
-	candidates
+	candidates,
 ) {
 	let transaction;
 	let poll;
@@ -72,6 +67,7 @@ export async function createPoll(
 
 	const state = "standby";
 	const pollDate = new Date();
+
 	try {
 		// get transaction
 		transaction = await sequelize.transaction();
@@ -87,7 +83,7 @@ export async function createPoll(
 				state,
 				pollDate,
 			},
-			{transaction}
+			{transaction},
 		);
 
 		// step 2
@@ -100,7 +96,7 @@ export async function createPoll(
 	} catch (err) {
 		// Rollback transaction only if the transaction object is defined
 		if (transaction) await transaction.rollback();
-		console.log("Transaction rollback", err);
+		logger.error("Transaction rollback", err);
 	}
 
 	if (poll && nItems) {

--- a/backend/DB/queries/question.js
+++ b/backend/DB/queries/question.js
@@ -1,5 +1,6 @@
 import Sequelize from "sequelize";
 import models from "../models";
+import logger from "../logger.js";
 
 const sequelize = models.sequelize;
 const Op = Sequelize.Op;
@@ -22,7 +23,7 @@ export async function createQuestion(
 }
 
 export async function getQuestionsByEventId(EventId) {
-	return models.Question.findAll({
+	return Question.findAll({
 		where: {EventId},
 	});
 }
@@ -59,19 +60,26 @@ export async function updateIsStared(from, to) {
 
 	try {
 		if (from) {
-			await Question.update({isStared: from.isStared},
+			await Question.update(
+				{isStared: from.isStared},
 				{where: {id: from.id}},
 				{transaction},
 			);
 		}
-		await Question.update({isStared: to.isStared},
+
+		await Question.update(
+			{isStared: to.isStared},
 			{where: {id: to.id}},
 			{transaction},
 		);
+
 		await transaction.commit();
 	} catch (err) {
-		if (transaction) await transaction.rollback();
-		console.log("Transaction rollback", err);
+		if (transaction) {
+			await transaction.rollback();
+		}
+
+		logger.error("Transaction rollback", err);
 	}
 }
 

--- a/backend/express/CookieKeys.js
+++ b/backend/express/CookieKeys.js
@@ -1,0 +1,6 @@
+const GUEST_APP = "vaagle-guest";
+const HOST_APP = "vaagle-host";
+
+export default {
+	GUEST_APP, HOST_APP,
+};

--- a/backend/express/app.js
+++ b/backend/express/app.js
@@ -1,19 +1,20 @@
-import {config} from "dotenv";
+import dotenv from "dotenv";
 import express from "express";
 import passport from "passport";
 import cors from "cors";
 import cookieParser from "cookie-parser";
 import morgan from "morgan";
-import loadConfig from "./config/configLoader.js";
+import config from "./config";
 import applyStaticAppServing from "./middleware/applyStaticAppServing.js";
 import "./authentication/google.js";
 import authRouter from "./routes/auth";
 import guestRouter from "./routes/guest";
 import hostRouter from "./routes/host";
+import logger from "./logger.js";
 
-config();
+dotenv.config()
 
-const {port, publicPath, routePage} = loadConfig();
+const {port, publicPath, routePage} = config;
 const app = express();
 
 applyStaticAppServing(app, publicPath);
@@ -32,10 +33,9 @@ app.get("/", (req, res, next) => {
 });
 
 app.listen(port, () => {
-	console.log(
-		`start express server at ${port} with ${process.env.NODE_ENV} mode`,
+	logger.info(
+		`start express server at ${port} with ${process.env.NODE_ENV} mode at public path = ${publicPath}`,
 	);
-	console.log(`public path = ${publicPath}`);
 });
 
 export default app;

--- a/backend/express/authentication/google.js
+++ b/backend/express/authentication/google.js
@@ -1,7 +1,8 @@
 import passport from "passport";
 import {Strategy} from "passport-google-oauth20";
-import loadConfig from "../config/configLoader";
+import config from "../config";
 import {createHost, findHostByAuthId} from "../../DB/queries/host";
+import logger from "../logger.js";
 
 const GoogleStrategy = Strategy;
 
@@ -11,6 +12,7 @@ function extractProfile(profile) {
 	if (profile.photos && profile.photos.length) {
 		imageUrl = profile.photos[0].value;
 	}
+
 	return {
 		id: profile.id,
 		displayName: profile.displayName,
@@ -19,9 +21,9 @@ function extractProfile(profile) {
 	};
 }
 
-export default (function() {
-	const {oAuthArgs} = loadConfig();
+const {oAuthArgs} = config;
 
+export default (function() {
 	const verify = async (accessToken, refreshToken, profile, cb) => {
 		try {
 			const {id, displayName, image, email} = extractProfile(profile);
@@ -30,9 +32,11 @@ export default (function() {
 			if (!host) {
 				host = await createHost(id, displayName, image, email);
 			}
+
 			return cb(null, host);
 		} catch (error) {
-			console.error(error);
+			logger.error(error);
+
 			return null;
 		}
 	};

--- a/backend/express/authentication/token.js
+++ b/backend/express/authentication/token.js
@@ -1,15 +1,14 @@
 import jwt from "jsonwebtoken";
-import loadConfig from "../config/configLoader";
+import config from "../config";
+
+const {tokenArgs} = config;
+const expiresIn = "24 hour";
 
 export default function generateAccessToken(sub, aud) {
-	const {tokenArgs} = loadConfig();
-	const expiresIn = "24 hour";
-	const token = jwt.sign({}, tokenArgs.secret, {
+	return jwt.sign({}, tokenArgs.secret, {
 		expiresIn,
 		issuer: tokenArgs.issuer,
 		audience: aud,
 		subject: sub,
 	});
-
-	return token;
 }

--- a/backend/express/config/index.js
+++ b/backend/express/config/index.js
@@ -1,9 +1,9 @@
-import {config} from "dotenv";
+import dotenv from "dotenv";
 import devConfig from "./express.dev.config.js";
 import prodConfig from "./express.prod.config.js";
 import testConfig from "./express.test.config.js";
 
-config();
+dotenv.config();
 
 function loadConfig() {
 	let configs = {};
@@ -19,4 +19,6 @@ function loadConfig() {
 	return configs;
 }
 
-export default loadConfig;
+const config = loadConfig();
+
+export default config;

--- a/backend/express/logger.js
+++ b/backend/express/logger.js
@@ -1,0 +1,5 @@
+import getLogger from "../libs/logger.js";
+
+const logger = getLogger("express");
+
+export default logger;

--- a/backend/express/middleware/authenticate.js
+++ b/backend/express/middleware/authenticate.js
@@ -1,7 +1,7 @@
 import jwt from "jsonwebtoken";
 import loadConfig from "../config/configLoader.js";
 import {findHostByAuthId} from "../../DB/queries/host";
-import {findGuestBySid} from "../../DB/queries/guest";
+import {isExistGuest} from "../../DB/queries/guest";
 import {convertePathToEvent} from "../utils";
 
 const {tokenArgs, routePage} = loadConfig();
@@ -16,7 +16,8 @@ export function guestAuthenticate() {
 				req.cookies[cookieName],
 				tokenArgs.secret
 			);
-			const guest = await findGuestBySid(payload.sub);
+
+			const guest = await isExistGuest(payload.sub);
 			const eventId = await convertePathToEvent(path);
 			const isAnotherPath = guest === eventId;
 			if (isAnotherPath) {

--- a/backend/express/routes/auth.js
+++ b/backend/express/routes/auth.js
@@ -2,9 +2,11 @@ import express from "express";
 import passport from "passport";
 import {getTokenExpired} from "../../libs/utils";
 import generateAccessToken from "../authentication/token";
-import loadConfig from "../config/configLoader";
+import config from "../config";
+import CookieKeys from "../CookieKeys.js";
 
-const {routePage} = loadConfig();
+const EXPIRE_TIME = 24;
+const {routePage} = config;
 const router = express.Router();
 
 router.get(
@@ -13,7 +15,7 @@ router.get(
 		session: false,
 		scope: ["email", "profile"],
 		prompt: "select_account",
-	})
+	}),
 );
 
 router.get(
@@ -24,8 +26,11 @@ router.get(
 	(req, res) => {
 		const accessToken = generateAccessToken(req.user.oauthId, "host");
 
-		res.cookie("vaagle-host", accessToken, {expires: getTokenExpired(24)});
+		res.cookie(CookieKeys.HOST_APP, accessToken, {
+			expires: getTokenExpired(EXPIRE_TIME),
+		});
 		res.redirect(routePage.host);
-	}
+	},
 );
-module.exports = router;
+
+export default router;

--- a/backend/express/routes/host.js
+++ b/backend/express/routes/host.js
@@ -1,13 +1,13 @@
 import express from "express";
-import loadConfig from "../config/configLoader";
+import config from "../config";
 import {hostAuthenticate} from "../middleware/authenticate";
+import CookieKeys from "../CookieKeys.js";
 
-const {routePage} = loadConfig();
+const {routePage} = config;
 const router = express.Router();
-const cookieName = "vaagle-host";
 
 router.get("/logout", (req, res, next) => {
-	res.clearCookie(cookieName).redirect(routePage.main);
+	res.clearCookie(CookieKeys.HOST_APP).redirect(routePage.main);
 });
 
 router.get("/", hostAuthenticate(), (req, res, next) => {

--- a/backend/graphQL/app.js
+++ b/backend/graphQL/app.js
@@ -10,33 +10,28 @@ import {findHostByAuthId} from "../DB/queries/host";
 import logger from "./logger.js";
 
 const authenticate = async (resolve, root, args, context, info) => {
-	let audience = "anonymous";
-
-	audience = context.payload && context.payload.aud;
+	const audience = context.payload && context.payload.aud;
 	let authority = {sub: null, info: null};
 
 	switch (audience) {
-		case "host":
-		{
+		case "host": {
 			const hostInfo = await findHostByAuthId(context.payload.sub);
 
 			authority = {sub: "host", info: hostInfo};
 			break;
 		}
-		case "guest":
-		{
+		case "guest": {
 			const guestInfo = context.payload.sub;
 
 			authority = {sub: "guest", info: guestInfo};
 			break;
 		}
-		default : {
-			// console.log(`unexpected type of audience ${audience}`)
+		default: {
+			logger.error(`unexpected type of audience ${audience}`);
 		}
 	}
-	const result = await resolve(root, args, authority, info);
 
-	return result;
+	return resolve(root, args, authority, info);
 };
 
 const server = new GraphQLServer({

--- a/backend/graphQL/model/guest/guest.resolver.js
+++ b/backend/graphQL/model/guest/guest.resolver.js
@@ -1,4 +1,7 @@
-import {getGuestByEventId, findGuestBySid} from "../../../DB/queries/guest.js";
+import {
+	getGuestByEventId,
+	getGuestByGuestSid,
+} from "../../../DB/queries/guest.js";
 import {getEventById} from "../../../DB/queries/event.js";
 
 const guestResolver = async EventId => getGuestByEventId(EventId);
@@ -8,10 +11,10 @@ const guestInEventResolver = async authority => {
 		throw Error("AuthenticationError in guestInEventResolver");
 	}
 
-	const guest = await findGuestBySid(authority.info);
-	const event = await getEventById(guest.EventId);
+	const guest = (await getGuestByGuestSid(authority.info)).get({plain: true});
+	const event = (await getEventById(guest.EventId)).get({plain: true});
 
-	return {event: event.dataValues, guest};
+	return {event, guest};
 };
 
 // noinspection JSUnusedGlobalSymbols

--- a/backend/libs/utils.js
+++ b/backend/libs/utils.js
@@ -3,6 +3,7 @@ import moment from "moment";
 const compareCurrentDateToTarget = baseDate => {
 	const endAt = moment(baseDate);
 	const current = moment();
+
 	return endAt.diff(current, "minute");
 };
 

--- a/backend/socket_io_server/socketHandler/Question/toggleModeration.socketHandler.js
+++ b/backend/socket_io_server/socketHandler/Question/toggleModeration.socketHandler.js
@@ -1,17 +1,21 @@
 import {updateEventById} from "../../../DB/queries/event";
 import eventCache from "../../EventCache";
+import logger from "../../logger.js";
 
 const toggleModerationSocketHandler = async (data, emit) => {
 	try {
 		const currentState = data.state;
 		const currentOption = await eventCache.get(data.eventId);
 
-		await updateEventById(data.eventId, {moderationOption: currentState});
+		await updateEventById({
+			id: data.eventId,
+			moderationOption: currentState,
+		});
 		currentOption.moderationOption = currentState;
 		await eventCache.set(data.eventId, currentOption);
 		emit({eventId: data.eventId, state: currentState});
 	} catch (e) {
-		console.log(e);
+		logger.error(e);
 		emit({status: "error", e});
 	}
 };

--- a/backend/spec/DB/QuestionQuery.test.js
+++ b/backend/spec/DB/QuestionQuery.test.js
@@ -1,4 +1,3 @@
-import {getQuestionLikeCount} from "../../DB/queries/event.js";
 import {
 	createQuestion,
 	deleteQuestionById,
@@ -45,15 +44,6 @@ describe("questions query api", () => {
 		// console.log(res.length);
 	});
 
-	it("should able to get question likeCount", async () => {
-		const eventId = 2;
-		const res = await getQuestionLikeCount(eventId);
-
-		QueryExpectMoreThanOne(res);
-		// res = res.map(x => x.get({ plain: true }));
-		// console.log(res.slice(0, 2));
-		// console.log(res.length);
-	});
 
 	it("should able to get by event id", async () => {
 		const eventId = 2;


### PR DESCRIPTION
전체적으로 마이너한 cleancode 레벨의 리펙토링

* DB query api 인자 전달을 일관성 있게 수정
* 불필요한 할당 제거 및 가독성을 위해 줄바꿈 추가
* lint fix
* express 와 DB query api에 logger 추가
* config 를 임포트 후 바로 사용가능할 수 있도록 수정
* express 의  모든 cookie key 이름을 상수로  변경하고, 한파일로 이동