### PR TITLE
fix: token 값이 없을 때 메인으로 리다이렉팅 되도록 에러처리

### DIFF
--- a/frontend/host-app/src/App/App.js
+++ b/frontend/host-app/src/App/App.js
@@ -7,6 +7,7 @@ import {HostProvider} from "../libs/hostContext";
 import {getEventsByHost} from "../libs/gql";
 import {socketClient} from "../libs/socket.io-Client-wrapper";
 import AppSkeleton from "../components/Skeleton/AppSkeleton";
+import config from "../config";
 import {compareCurrentDateToTarget} from "../libs/utils";
 
 const initialValue = "";
@@ -27,7 +28,8 @@ function App() {
 	if (loading) {
 		return <AppSkeleton />;
 	} else if (error) {
-		return <p>error-page...</p>;
+		window.location.href = config.inValidHostRedirectURL;
+		return <div />;
 	}
 	initialLoadEvents(events, initialValue, setEvents, data.init.events);
 

--- a/frontend/host-app/src/config/env.dev.config.js
+++ b/frontend/host-app/src/config/env.dev.config.js
@@ -3,6 +3,7 @@ const config = {
 	websocketHost: "http://127.0.0.1",
 	websocketPort: 4001,
 	apolloURI: "http://localhost:8000/graphql",
+	inValidHostRedirectURL: "http://localhost:5000",
 };
 
 export default config;

--- a/frontend/host-app/src/config/env.prod.config.js
+++ b/frontend/host-app/src/config/env.prod.config.js
@@ -3,6 +3,7 @@ const config = {
 	websocketHost: "http://www.vaagle.com",
 	websocketPort: 4000,
 	apolloURI: "http://www.vaagle.com:8000/graphql",
+	inValidGuestRedirectURL: "http://www.vaagle.com",
 };
 
 export default config;


### PR DESCRIPTION
host page에서 token 값이 없을 때 error-page를 띄우던 것을 자연스럽게 메인으로 리다이렉팅 될 수 있도록 수정.

frontend/hostpage/App.js
30번 째 줄
기존 <p>error-page</p> 이던 것을
main으로 redirect 시킴