### PR TITLE
Hotfix/socket.io server hanlder bug

### DIFF
--- a/backend/socket_io_server/RoomSocket.js
+++ b/backend/socket_io_server/RoomSocket.js
@@ -3,6 +3,7 @@ class RoomSocket {
 		this.socket = socket;
 		this.server = server;
 		this.handlerPair = handlerEventPair;
+		this.registeredHandler = [];
 	}
 
 	joinRoom(room) {
@@ -10,8 +11,8 @@ class RoomSocket {
 
 		this.socket.join(this.room);
 
-		this.handlerPair.map(({eventName, handler}) =>
-			this.addListener(eventName, handler),
+		this.registeredHandler = this.handlerPair.map(({eventName, handler}) =>
+			this.addListener(eventName, handler)
 		);
 
 		this.socket.emit("joinRoom");
@@ -20,13 +21,14 @@ class RoomSocket {
 	leaveRoom() {
 		this.socket.leave(this.room);
 
-		this.handlerPair.map(({eventName, handler}) =>
-			this.removeListener(eventName, handler),
+		this.registeredHandler.map(({eventName, handler}) =>
+			this.socket.removeListener(eventName, handler)
 		);
 
 		this.socket.emit("leaveRoom");
 
 		this.room = null;
+		this.registeredHandler = [];
 	}
 
 	addListener(event, handler) {
@@ -39,10 +41,11 @@ class RoomSocket {
 		};
 
 		this.socket.on(event, wrappedSocketHandler);
-	}
 
-	removeListener(event, handler) {
-		this.socket.off(event, handler);
+		return {
+			eventName: event,
+			handler: wrappedSocketHandler,
+		};
 	}
 }
 

--- a/backend/socket_io_server/RoomSocketHelper.js
+++ b/backend/socket_io_server/RoomSocketHelper.js
@@ -26,10 +26,10 @@ const RoomSocketHelper = ({server, socket, handlerEventPair}) => {
 	};
 
 	const onLeaveRoom = async () => {
-		if (currentRoom === null) {
-			logger.error(`id: ${id} is not in room`);
-			return;
-		}
+		// if (currentRoom === null) {
+		// 	logger.error(`id: ${id} is not in room`);
+		// 	return;
+		// }
 
 		try {
 			roomSocket.leaveRoom();

--- a/frontend/host-app/src/App/App.js
+++ b/frontend/host-app/src/App/App.js
@@ -46,6 +46,8 @@ function App() {
 		activeEventsNum = activeEvents.length;
 		if (activeEventsNum) {
 			const eventId = activeEvents[0].id;
+
+			socketClient.emit("leaveRoom");
 			socketClient.emit("joinRoom", {room: eventId});
 			socketClient.emit("event/initOption", eventId);
 		}

--- a/frontend/host-app/src/components/EventSettingModal/EventSettingTab/GeneralSetting/InputStartDate.js
+++ b/frontend/host-app/src/components/EventSettingModal/EventSettingTab/GeneralSetting/InputStartDate.js
@@ -67,7 +67,6 @@ function InputStartDate(props) {
 					label="남은시간"
 					value={lastTime}
 					onChange={calcEndDate}
-					readOnly={true}
 					minutesStep={5}
 				/>
 			</MuiPickersUtilsProvider>


### PR DESCRIPTION
* hotfix: socket.io server handler 제거가 안되는 버그 
    원인: 제거할 wrapping된 handler를 인자로 넘겨주지 않음

* hotfix: host-app의 남은 시간이 변경되지 않는 버그 수정 
    readonly 옵션을 제거함