### PR TITLE
Fix and enhance db query api unit test

### DIFF
--- a/backend/DB/dummy/emojiDummies.js
+++ b/backend/DB/dummy/emojiDummies.js
@@ -11,7 +11,7 @@ export default async function makeEmojiDummy(number = 500) {
 
 	for (let i = 0; i < number; ++i) {
 		const QuestionId = faker.random.number({min: 1, max: 100});
-		const GuestId = (await getQuestionById(QuestionId)).dataValues.GuestId;
+		const GuestId = (await getQuestionById(QuestionId)).GuestId;
 		const name = faker.random.arrayElement(["one", "two", "three", "four"]);
 		const createdAt = faker.date.past(1);
 		const updatedAt = createdAt;
@@ -24,7 +24,7 @@ export default async function makeEmojiDummy(number = 500) {
 			name,
 			createdAt,
 			updatedAt,
-			EventId: res.dataValues.EventId,
+			EventId: res.EventId,
 		});
 	}
 	return bulkEmoji;

--- a/backend/DB/dummy/likeDummies.js
+++ b/backend/DB/dummy/likeDummies.js
@@ -15,7 +15,7 @@ export default async function makeLikeDummy(number = 100) {
 		const updatedAt = createdAt;
 		const QuestionId = faker.random.number({min: 1, max: 100});
 		// eslint-disable-next-line no-await-in-loop
-		const EventId = (await getQuestionById(QuestionId)).dataValues.EventId;
+		const EventId = (await getQuestionById(QuestionId)).EventId;
 		// eslint-disable-next-line no-await-in-loop
 		const candidate = await getGuestByEventId(EventId);
 		const candidateIdx = faker.random.number({
@@ -23,7 +23,7 @@ export default async function makeLikeDummy(number = 100) {
 			max: candidate.length - 1,
 		});
 
-		const GuestId = candidate[candidateIdx].dataValues.id;
+		const GuestId = candidate[candidateIdx].id;
 
 		bulkLike.push({createdAt, updatedAt, GuestId, QuestionId});
 	}

--- a/backend/DB/dummy/questionDummies.js
+++ b/backend/DB/dummy/questionDummies.js
@@ -17,7 +17,7 @@ export default async function makeQuestionDummy(number = 100) {
 		const GuestId = faker.random.number({min: 1, max: GUEST_NUM});
 		// eslint-disable-next-line no-await-in-loop
 		const res = await getGuestById(GuestId);
-		const EventId = res.dataValues.EventId;
+		const EventId = res.EventId;
 		const QuestionId = null;
 		const isStared = false;
 		const likeCount = 0;

--- a/backend/DB/dummy/replyDummies.js
+++ b/backend/DB/dummy/replyDummies.js
@@ -18,14 +18,14 @@ export default async function makeReplyDummy(number = 200) {
 
 		const QuestionId = faker.random.number({min: 1, max: 100});
 		// eslint-disable-next-line no-await-in-loop
-		const EventId = (await getQuestionById(QuestionId)).dataValues.EventId;
+		const EventId = (await getQuestionById(QuestionId)).EventId;
 		// eslint-disable-next-line no-await-in-loop
 		const candidates = await getGuestByEventId(EventId);
 		const candidateGuestIdx = faker.random.number({
 			min: 0,
 			max: candidates.length - 1,
 		});
-		const GuestId = candidates[candidateGuestIdx].dataValues.id;
+		const GuestId = candidates[candidateGuestIdx].id;
 		const isStared = false;
 
 		bulkQuestion.push({

--- a/backend/DB/queries/emoji.js
+++ b/backend/DB/queries/emoji.js
@@ -5,12 +5,14 @@ import models from "../models";
 const Emoji = models.Emoji;
 
 export async function createEmoji({GuestId, QuestionId, name, EventId}) {
-	return Emoji.create({
+	const res = await Emoji.create({
 		GuestId,
 		QuestionId,
 		name,
 		EventId,
 	});
+
+	return res.get({plain: true});
 }
 
 export async function deleteEmojiById(id) {
@@ -24,7 +26,9 @@ export async function deleteEmojiBy({name, GuestId, QuestionId}) {
 }
 
 export async function getDidIPicked({name, QuestionId, GuestId}) {
-	return Emoji.findAll({where: {name, QuestionId, GuestId}});
+	const res = await Emoji.findAll({where: {name, QuestionId, GuestId}});
+
+	return res.map(x => x.get({plain: true}));
 }
 
 export async function getEmojiCountBy({name, QuestionId}) {
@@ -41,8 +45,10 @@ export async function getEmojiCountByEventIdGroupByQuestionId({EventId}) {
 }
 
 export async function getEmojiPick({GuestId, EventId}) {
-	return Emoji.findAll({
+	const res = await Emoji.findAll({
 		where: {GuestId, EventId},
 		attributes: ["name", "QuestionId"],
 	});
+
+	return res.map(x => x.get({plain: true}));
 }

--- a/backend/DB/queries/emoji.js
+++ b/backend/DB/queries/emoji.js
@@ -4,6 +4,14 @@ import models from "../models";
 // noinspection JSUnresolvedVariable
 const Emoji = models.Emoji;
 
+/**
+ *
+ * @param GuestId fk to guest table
+ * @param QuestionId fk to question table
+ * @param name name of emoji
+ * @param EventId fk to event table
+ * @returns {Promise<object>}
+ */
 export async function createEmoji({GuestId, QuestionId, name, EventId}) {
 	const res = await Emoji.create({
 		GuestId,
@@ -15,26 +23,56 @@ export async function createEmoji({GuestId, QuestionId, name, EventId}) {
 	return res.get({plain: true});
 }
 
+/**
+ *
+ * @param id id of emoji
+ * @returns {Promise<Number>}
+ */
 export async function deleteEmojiById(id) {
 	return Emoji.destroy({
 		where: {id},
 	});
 }
 
+/**
+ *
+ * @param name name of emoji
+ * @param GuestId fk to guest table
+ * @param QuestionId fk to question table
+ * @returns {Promise<Number>}
+ */
 export async function deleteEmojiBy({name, GuestId, QuestionId}) {
 	return Emoji.destroy({where: {name, GuestId, QuestionId}});
 }
 
+/**
+ *
+ * @param name name of emoji
+ * @param QuestionId fk to question table
+ * @param GuestId fk to guest table
+ * @returns {Promise<object[]>}
+ */
 export async function getDidIPicked({name, QuestionId, GuestId}) {
 	const res = await Emoji.findAll({where: {name, QuestionId, GuestId}});
 
 	return res.map(x => x.get({plain: true}));
 }
 
+/**
+ *
+ * @param name name of emoji
+ * @param QuestionId fk to question table
+ * @returns {Promise<number>}
+ */
 export async function getEmojiCountBy({name, QuestionId}) {
 	return Emoji.count({where: {name, QuestionId}});
 }
 
+/**
+ *
+ * @param EventId fk to event table
+ * @returns {Promise<object[]>}
+ */
 export async function getEmojiCountByEventIdGroupByQuestionId({EventId}) {
 	return Emoji.findAll({
 		attributes: ["QuestionId", "name", [sequelize.fn("count", "id"), "count"], [sequelize.literal("MIN(createdAt)"), "createdAt"]],
@@ -44,6 +82,12 @@ export async function getEmojiCountByEventIdGroupByQuestionId({EventId}) {
 	});
 }
 
+/**
+ *
+ * @param GuestId fk to guest table
+ * @param EventId fk to event table
+ * @returns {Promise<object[]>}
+ */
 export async function getEmojiPick({GuestId, EventId}) {
 	const res = await Emoji.findAll({
 		where: {GuestId, EventId},

--- a/backend/DB/queries/event.js
+++ b/backend/DB/queries/event.js
@@ -1,9 +1,26 @@
 import models from "../models";
 
+/**
+ *
+ * @returns {Promise<object[]|any[]>}
+ */
 export async function getAllEvents() {
-	return models.Event.findAll();
+	const res = await models.Event.findAll();
+
+	return res.map(x => x.get({plain: true}));
 }
 
+/**
+ *
+ * @param eventName {String}
+ * @param eventCode {String}
+ * @param HostId {number|null}
+ * @param moderationOption {boolean|undefined}
+ * @param replyOption {boolean|undefined}
+ * @param startAt {Date}
+ * @param endAt {Date}
+ * @returns {Promise<object>}
+ */
 export async function createEvent({
 	eventName,
 	eventCode,
@@ -13,7 +30,7 @@ export async function createEvent({
 	startAt = new Date(),
 	endAt = new Date(),
 }) {
-	return models.Event.findOrCreate({
+	const res = await models.Event.findOrCreate({
 		where: {eventCode},
 		defaults: {
 			eventName,
@@ -24,8 +41,20 @@ export async function createEvent({
 			endAt,
 		},
 	});
+
+	return res[0].get({plain: true});
 }
 
+/**
+ *
+ * @param id {number}
+ * @param eventName {string|undefined}
+ * @param moderationOption {boolean|undefined}
+ * @param replyOption {boolean|undefined}
+ * @param startAt {Date|undefined}
+ * @param endAt {Date|undefined}
+ * @returns {Promise<Number>}
+ */
 export async function updateEventById({
 	id,
 	eventName,
@@ -34,39 +63,81 @@ export async function updateEventById({
 	startAt,
 	endAt,
 }) {
-	return models.Event.update(
+	const res = await models.Event.update(
 		{eventName, moderationOption, replyOption, startAt, endAt},
 		{where: {id}},
 	);
+
+	return res[0];
 }
 
+/**
+ *
+ * @param hostId {number|null}
+ * @returns {Promise<object[]>}
+ */
 export async function getEventsByHostId(hostId) {
-	return models.Event.findAll({
+	const res = models.Event.findAll({
 		where: {HostId: hostId},
 	});
+
+	return res.map(x => x.get({plain: true}));
 }
 
+/**
+ *
+ * @param eventCode {string}
+ * @returns {Promise<Object|null>}
+ */
 export async function getEventByEventCode(eventCode) {
-	return models.Event.findOne({
+	let res = await models.Event.findOne({
 		where: {
 			eventCode,
 		},
 	});
+
+	if (res !== null) {
+		res = res.get({plain: true});
+	}
+
+	return res;
 }
 
-export async function getEventById(EventId) {
-	return models.Event.findOne({
+/**
+ *
+ * @param id {number}
+ * @returns {Promise<Model<any, any>|null|any>}
+ */
+export async function getEventById(id) {
+	let res = await models.Event.findOne({
 		where: {
-			id: EventId,
+			id,
 		},
 	});
+
+	if (res !== null) {
+		res = res.get({plain: true});
+	}
+
+	return res;
 }
 
+/**
+ *
+ * @param id {number}
+ * @returns {Promise<object|null>}
+ */
 export async function getEventOptionByEventId(id) {
-	return models.Event.findOne({
+	let res = await models.Event.findOne({
 		where: {
 			id,
 		},
 		attributes: ["moderationOption", "replyOption"],
 	});
+
+	if (res !== null) {
+		res = res.get({plain: true});
+	}
+
+	return res;
 }

--- a/backend/DB/queries/guest.js
+++ b/backend/DB/queries/guest.js
@@ -6,16 +6,37 @@ import getRandomGuestName from "../dummy/RandomGuestName";
 // noinspection JSUnresolvedVariable
 const Guest = models.Guest;
 
-async function getGuestByGuestSid(guestSid) {
-	return Guest.findOne({where: {guestSid}});
+/**
+ *
+ * @param guestSid {string}
+ * @returns {Promise<object|null>}
+ */
+export async function getGuestByGuestSid(guestSid) {
+	let res = await Guest.findOne({where: {guestSid}});
+
+	if (res !== null) {
+		res = res.get({plain: true});
+	}
+
+	return res;
 }
 
 // todo refactoring
-async function isExistGuest(guestSid) {
+/**
+ *
+ * @param guestSid {string}
+ * @returns {Promise<boolean>}
+ */
+export async function isExistGuest(guestSid) {
 	return !!(await getGuestByGuestSid(guestSid));
 }
 
-async function createGuest(eventId) {
+/**
+ *
+ * @param eventId {number|null}
+ * @returns {Promise<object>}
+ */
+export async function createGuest(eventId) {
 	const guest = await Guest.create({
 		name: getRandomGuestName(),
 		EventId: eventId,
@@ -26,25 +47,48 @@ async function createGuest(eventId) {
 	return guest.get({plain: true});
 }
 
-async function getGuestById(id) {
-	return Guest.findOne({
+/**
+ *
+ * @param id {number}
+ * @returns {Promise<object|null>}
+ */
+export async function getGuestById(id) {
+	let res = await Guest.findOne({
 		where: {id},
 	});
+
+	if (res !== null) {
+		res = res.get({plain: true});
+	}
+
+	return res;
 }
 
-async function updateGuestById({id, name, isAnonymous, company, email}) {
-	return Guest.update({name, company, isAnonymous, email}, {where: {id}});
+/**
+ *
+ * @param id {number}
+ * @param name {string|undefined}
+ * @param isAnonymous {boolean|undefined}
+ * @param company {string|undefined}
+ * @param email {string|undefined}
+ * @returns {Promise<number>}
+ */
+export async function updateGuestById({id, name, isAnonymous, company, email}) {
+	const res = await Guest.update(
+		{name, company, isAnonymous, email},
+		{where: {id}},
+	);
+
+	return res[0];
 }
 
-async function getGuestByEventId(EventId) {
-	return Guest.findAll({where: {EventId}});
-}
+/**
+ *
+ * @param EventId {number}
+ * @returns {Promise<Model[]|any[]>}
+ */
+export async function getGuestByEventId(EventId) {
+	const res = Guest.findAll({where: {EventId}});
 
-export {
-	createGuest,
-	getGuestById,
-	updateGuestById,
-	getGuestByEventId,
-	isExistGuest,
-	getGuestByGuestSid,
-};
+	return res.map(x => x.get({plain: true}));
+}

--- a/backend/DB/queries/hashtag.js
+++ b/backend/DB/queries/hashtag.js
@@ -3,25 +3,59 @@ import models from "../models";
 // noinspection JSUnresolvedVariable
 const Hashtag = models.Hashtag;
 
+/**
+ *
+ * @param name {string}
+ * @param EventId {number|null}
+ * @returns {Promise<object>}
+ */
 export async function createHashtag({name, EventId}) {
-	return Hashtag.create(
+	const res = await Hashtag.create(
 		{name, EventId},
 		{default: {updateAt: new Date(), createAt: new Date()}},
 	);
+
+	return res.get({plain: true});
 }
 
+
+/**
+ *
+ * @param name <string>
+ * @param id <number>
+ * @returns {Promise<number>}
+ */
 export async function updateHashtagById({name, id}) {
 	return Hashtag.update({name}, {where: {id}});
 }
 
+/**
+ *
+ * @param id {number}
+ * @returns {Promise<number>}
+ */
 export async function deleteHashTagById(id) {
 	return Hashtag.destroy({where: {id}});
 }
 
+/**
+ *
+ * @param EventId {number|null}
+ * @returns {Promise<object[]>}
+ */
 export async function getHashtagByEventId(EventId) {
-	return Hashtag.findAll({where: {EventId}});
+	const res = await Hashtag.findAll({where: {EventId}});
+
+	return res.map(x => x.get({plain: true}));
 }
 
+/**
+ *
+ * @param EventIdList {number[]}
+ * @returns {Promise<object[]>}
+ */
 export async function getHashtagByEventIds(EventIdList) {
-	return Hashtag.findAll({where: {EventId: EventIdList}});
+	const res = await Hashtag.findAll({where: {EventId: EventIdList}});
+
+	return res.map(x => x.get({plain: true}));
 }

--- a/backend/DB/queries/host.js
+++ b/backend/DB/queries/host.js
@@ -3,12 +3,31 @@ import models from "../models";
 // noinspection JSUnresolvedVariable
 const Host = models.Host;
 
-// todo: 더 좋은 이름
-// todo refactoring
-export async function findHostByAuthId(oauthId) {
-	const host = await Host.findOne({where: {oauthId}});
 
-	return host ? host.dataValues : false;
+/**
+ *
+ * @param oauthId {String}
+ * @returns {Promise<Model<any, any>|any>}
+ */
+export async function findHostByOAuthId(oauthId) {
+	let res = await Host.findOne({where: {oauthId}});
+
+	if (res !== null) {
+		res = res.get({plain: true});
+	}
+
+	return res;
+}
+
+/**
+ *
+ * @param oauthId {String}
+ * @returns {Promise<boolean>}
+ */
+export async function isExistHostOAuthId(oauthId) {
+	const host = await findHostByOAuthId(oauthId);
+
+	return !!host;
 }
 
 /**

--- a/backend/DB/queries/host.js
+++ b/backend/DB/queries/host.js
@@ -11,15 +11,19 @@ export async function findHostByAuthId(oauthId) {
 	return host ? host.dataValues : false;
 }
 
-// todo refactoring
-export async function createHost(oauthId, name, image, email) {
-	const host = await Host.create({
-		oauthId,
-		name,
-		email,
-		image,
-		emailFeedBack: false,
+/**
+ *
+ * @param oauthId {string}
+ * @param name {string|undefined}
+ * @param image {string|undefined}
+ * @param email {string|undefined}
+ * @returns {Promise<object>}
+ */
+export async function findOrCreateHostByOAuth({oauthId, name, image, email}) {
+	const res = await Host.findOrCreate({
+		where: {oauthId},
+		defaults: {name, image, email, emailFeedBack: false},
 	});
 
-	return host ? host.dataValues : false;
+	return res[0].get({plain: true});
 }

--- a/backend/DB/queries/like.js
+++ b/backend/DB/queries/like.js
@@ -3,41 +3,40 @@ import models from "../models";
 // noinspection JSUnresolvedVariable
 const Like = models.Like;
 
-export async function createLike(GuestId, QuestionId) {
-	return Like.create({
+/**
+ *
+ * @param GuestId {number|null}
+ * @param QuestionId {number|null}
+ * @returns {Promise<object>}
+ */
+export async function createLike({GuestId, QuestionId}) {
+	const res = await Like.create({
 		GuestId,
 		QuestionId,
 	});
+
+	return res.get({plain: true});
 }
 
-export async function deleteLikeById(id) {
-	return Like.destroy({
-		where: {id},
-	});
-}
-
+/**
+ *
+ * @param GuestId {number|null}
+ * @param QuestionId {number|null}
+ * @returns {Promise<number>}
+ */
 export async function deleteLikeBy({GuestId, QuestionId}) {
 	return Like.destroy({where: {GuestId, QuestionId}});
 }
 
+/**
+ *
+ * @param GuestId {number|null}
+ * @returns {Promise<Object[]>}
+ */
 export async function getLikesByGuestId(GuestId) {
-	return Like.findAll({
+	const res = await Like.findAll({
 		where: {GuestId},
 	});
-}
 
-export async function getLikesByQuestionId(QuestionId) {
-	return Like.findAll({
-		where: {QuestionId},
-	});
-}
-
-export async function getLikeCountByQuestion(QuestionId) {
-	return Like.count({
-		where: {QuestionId},
-	});
-}
-
-export async function getDidILikes({QuestionId, GuestId}) {
-	return Like.findOne({where: {QuestionId, GuestId}});
+	return res.map(x => x.get({plain: true}));
 }

--- a/backend/DB/queries/question.js
+++ b/backend/DB/queries/question.js
@@ -7,44 +7,89 @@ const Op = Sequelize.Op;
 // noinspection JSUnresolvedVariable
 const Question = models.Question;
 
-export async function createQuestion(
+/**
+ *
+ * @param EventId <number|null>
+ * @param content <String>
+ * @param GuestId <number|null>
+ * @param QuestionId <number|null>
+ * @param state <String|null>
+ * @returns {Promise<object>}
+ */
+export async function createQuestion({
 	EventId,
 	content,
 	GuestId,
 	QuestionId,
 	state = "active",
-) {
-	return Question.create({
+}) {
+	const res = await Question.create({
 		content,
 		EventId,
 		GuestId,
 		QuestionId,
 		state,
 	});
+
+	return res.get({plain: true});
 }
 
+/**
+ *
+ * @param EventId {number|null}
+ * @returns {Promise<object[]>}
+ */
 export async function getQuestionsByEventId(EventId) {
-	return Question.findAll({
+	const res = await Question.findAll({
 		where: {EventId},
 	});
+
+	return res.map(x => x.get({plain: true}));
 }
 
+/**
+ *
+ * @param EventId {number|null}
+ * @returns {Promise<object[]>}
+ */
 export async function getQuestionReplyByEventId(EventId) {
-	return Question.findAll({
+	const res = await Question.findAll({
 		where: {EventId, QuestionId: {[Op.ne]: null}},
 	});
+
+	return res.map(x => x.get({plain: true}));
 }
 
+/**
+ *
+ * @param GuestId <number|null>
+ * @returns {Promise<object[]>}
+ */
 export async function getQuestionByGuestId(GuestId) {
-	return Question.findAll({
+	const res = await Question.findAll({
 		where: {GuestId},
 	});
+
+	return res.map(x => x.get({plain: true}));
 }
 
+/**
+ *
+ * @param id {number}
+ * @returns {Promise<number>}
+ */
 export async function deleteQuestionById(id) {
 	return Question.destroy({where: {id}});
 }
 
+/**
+ *
+ * @param id <number>
+ * @param content <string|undefined>
+ * @param state <string>
+ * @param isStared <Boolean>
+ * @returns {Promise<number>}
+ */
 export async function updateQuestionById({id, content, state, isStared}) {
 	return Question.update(
 		{
@@ -56,21 +101,28 @@ export async function updateQuestionById({id, content, state, isStared}) {
 	);
 }
 
-export async function updateIsStared(from, to) {
+/**
+ *
+ * @param from <number>
+ * @param to <number>
+ * @returns {Promise<void>}
+ */
+export async function updateQuestionIsStared({from, to}) {
+	// todo simplify transaction
 	const transaction = await sequelize.transaction();
 
 	try {
 		if (from) {
 			await Question.update(
-				{isStared: from.isStared},
-				{where: {id: from.id}},
+				{isStared: false},
+				{where: {id: from}},
 				{transaction},
 			);
 		}
 
 		await Question.update(
-			{isStared: to.isStared},
-			{where: {id: to.id}},
+			{isStared: true},
+			{where: {id: to}},
 			{transaction},
 		);
 
@@ -84,6 +136,22 @@ export async function updateIsStared(from, to) {
 	}
 }
 
+/**
+ *
+ * @param id {number}
+ * @returns {Promise<object|null>}
+ */
+export async function getQuestionById(id) {
+	let res = await Question.findOne({where: {id}});
+
+	if (res) {
+		res = res.get({plain: true});
+	}
+
+	return res;
+}
+
+// todo what ???
 export async function updateEveryState(from, {state}) {
 	return Question.update(
 		{
@@ -91,8 +159,4 @@ export async function updateEveryState(from, {state}) {
 		},
 		{where: {state: from}},
 	);
-}
-
-export async function getQuestionById(id) {
-	return Question.findOne({where: {id}});
 }

--- a/backend/express/authentication/google.js
+++ b/backend/express/authentication/google.js
@@ -1,7 +1,7 @@
 import passport from "passport";
 import {Strategy} from "passport-google-oauth20";
 import config from "../config";
-import {createHost, findHostByAuthId} from "../../DB/queries/host";
+import {findOrCreateHostByOAuth} from "../../DB/queries/host";
 import logger from "../logger.js";
 
 const GoogleStrategy = Strategy;
@@ -27,11 +27,13 @@ export default (function() {
 	const verify = async (accessToken, refreshToken, profile, cb) => {
 		try {
 			const {id, displayName, image, email} = extractProfile(profile);
-			let host = await findHostByAuthId(id);
 
-			if (!host) {
-				host = await createHost(id, displayName, image, email);
-			}
+			const host = await findOrCreateHostByOAuth({
+				oauthId: id,
+				name: displayName,
+				image,
+				email,
+			});
 
 			return cb(null, host);
 		} catch (error) {

--- a/backend/express/middleware/authenticate.js
+++ b/backend/express/middleware/authenticate.js
@@ -1,10 +1,10 @@
 import jwt from "jsonwebtoken";
 import config from "../config";
-import {findHostByAuthId} from "../../DB/queries/host";
 import {isExistGuest} from "../../DB/queries/guest";
 import {convertPathToEventId} from "../utils";
 import logger from "../logger.js";
 import CookieKeys from "../CookieKeys.js";
+import {isExistHostOAuthId} from "../../DB/queries/host.js";
 
 const {tokenArgs, routePage} = config;
 
@@ -41,9 +41,9 @@ export function hostAuthenticate() {
 				req.cookies[CookieKeys.HOST_APP],
 				tokenArgs.secret,
 			);
-			const host = await findHostByAuthId(payload.sub);
+			const isExist = await isExistHostOAuthId(payload.sub);
 
-			if (host) {
+			if (isExist) {
 				res.redirect(routePage.host);
 			}
 

--- a/backend/express/utils.js
+++ b/backend/express/utils.js
@@ -4,9 +4,7 @@ import {compareCurrentDateToTarget} from "../libs/utils";
 // eslint-disable-next-line import/prefer-default-export
 export async function convertPathToEventId(path) {
 	const eventCode = Buffer.from(path, "base64").toString();
-	let event = await getEventByEventCode(eventCode);
-
-	event = event.get({plain: true});
+	const event = await getEventByEventCode(eventCode);
 	const diff = compareCurrentDateToTarget(event.endAt);
 
 	if (diff <= 0) {

--- a/backend/graphQL/middlewares/authenticate.js
+++ b/backend/graphQL/middlewares/authenticate.js
@@ -1,4 +1,4 @@
-import {findHostByAuthId} from "../../DB/queries/host.js";
+import {findHostByOAuthId} from "../../DB/queries/host.js";
 import logger from "../logger.js";
 
 const authenticate = async (resolve, root, args, context, info) => {
@@ -7,7 +7,7 @@ const authenticate = async (resolve, root, args, context, info) => {
 
 	switch (audience) {
 		case "host": {
-			const hostInfo = await findHostByAuthId(context.payload.sub);
+			const hostInfo = await findHostByOAuthId(context.payload.sub);
 
 			authority = {sub: "host", info: hostInfo};
 			break;

--- a/backend/graphQL/model/guest/guest.resolver.js
+++ b/backend/graphQL/model/guest/guest.resolver.js
@@ -11,7 +11,7 @@ const guestInEventResolver = async authority => {
 		throw Error("AuthenticationError in guestInEventResolver");
 	}
 
-	const guest = (await getGuestByGuestSid(authority.info)).get({plain: true});
+	const guest = await getGuestByGuestSid(authority.info);
 	const event = await getEventById(guest.EventId);
 
 	return {event, guest};

--- a/backend/graphQL/model/guest/guest.resolver.js
+++ b/backend/graphQL/model/guest/guest.resolver.js
@@ -12,7 +12,7 @@ const guestInEventResolver = async authority => {
 	}
 
 	const guest = (await getGuestByGuestSid(authority.info)).get({plain: true});
-	const event = (await getEventById(guest.EventId)).get({plain: true});
+	const event = await getEventById(guest.EventId);
 
 	return {event, guest};
 };

--- a/backend/graphQL/model/hostpage/hostpage.resolver.js
+++ b/backend/graphQL/model/hostpage/hostpage.resolver.js
@@ -60,8 +60,6 @@ export default {
 			const host = authority.info;
 			let events = await getEventsByHostId(host.id);
 
-			events = events.filter(event => event.get({plain: true}));
-
 			const eventMap = new Map();
 			const eventIdList = events.map(event => {
 				eventMap.set(event.id, []);
@@ -94,8 +92,7 @@ export default {
 		createEvent: async (_, {info}, authority) => {
 			verifySubjectHostJwt(authority.sub);
 			const eventCode = await generateEventCode();
-
-			let event = await createEvent({
+			const event = await createEvent({
 				eventName: info.eventName,
 				eventCode,
 				HostId: authority.info.id,
@@ -103,7 +100,6 @@ export default {
 				endAt: info.endAt,
 			});
 
-			event = event[0].get({plain: true});
 			return {...event};
 		},
 

--- a/backend/graphQL/model/hostpage/hostpage.resolver.js
+++ b/backend/graphQL/model/hostpage/hostpage.resolver.js
@@ -20,9 +20,7 @@ function verifySubjectHostJwt(jwtSub) {
 
 function mappingHashTagsToEvents(hashTags, events, eventMap) {
 	hashTags.forEach(hashTag => {
-		const hashTagObject = hashTag.get({plain: true});
-
-		eventMap.get(hashTagObject.EventId).push(hashTagObject);
+		eventMap.get(hashTag.EventId).push(hashTag);
 	});
 	events.forEach(event => {
 		Object.assign(event, {HashTags: eventMap.get(event.id)});

--- a/backend/socket_io_server/middleware/authenticate.js
+++ b/backend/socket_io_server/middleware/authenticate.js
@@ -1,12 +1,12 @@
 import jwt from "jsonwebtoken";
 import loadConfig from "../config/configLoader";
 import logger from "../logger";
-import {findHostByAuthId} from "../../DB/queries/host";
+import {isExistHostOAuthId} from "../../DB/queries/host";
 import {isExistGuest} from "../../DB/queries/guest";
 
 const {tokenArgs} = loadConfig();
 
-const audienceVerify = {guest: isExistGuest, host: findHostByAuthId};
+const audienceVerify = {guest: isExistGuest, host: isExistHostOAuthId};
 
 const isValidAud = aud => aud !== "guest" && aud !== "host";
 

--- a/backend/socket_io_server/socketHandler/Event/initOption.socketHandler.js
+++ b/backend/socket_io_server/socketHandler/Event/initOption.socketHandler.js
@@ -6,7 +6,7 @@ const initOptionSocketHandler = async (data, emit) => {
 	try {
 		const currentState = await getEventOptionByEventId(data); // dummy event Id
 
-		await eventCache.set(data.eventId, currentState.get({plain: true}));
+		await eventCache.set(data.eventId, currentState);
 	} catch (e) {
 		logger.error(e);
 		emit({status: "error", e});

--- a/backend/socket_io_server/socketHandler/Question/createQuestion.socketHandler.js
+++ b/backend/socket_io_server/socketHandler/Question/createQuestion.socketHandler.js
@@ -55,26 +55,21 @@ const createQuestionSocketHandler = async (data, emit, socket) => {
 		const event = await eventCache.get(EventId);
 		const currentModerationOption = event.moderationOption;
 		const reqData = newQuestion;
-		let newData;
+		let state;
 
-		// todo 성능 개선: 위해 여러개의 DB query를 promise.all 처리해야함
 		if (currentModerationOption) {
 			reqData.state = QUESTION_STATE_MODERATION;
-			newData = await createQuestion(
-				EventId,
-				content,
-				GuestId,
-				QuestionId,
-				QUESTION_STATE_MODERATION,
-			);
-		} else {
-			newData = await createQuestion(
-				EventId,
-				content,
-				GuestId,
-				QuestionId,
-			);
+			state = QUESTION_STATE_MODERATION;
 		}
+
+		// todo 성능 개선: 위해 여러개의 DB query를 promise.all 처리해야함
+		const newData = await createQuestion({
+			EventId,
+			content,
+			GuestId,
+			QuestionId,
+			state,
+		});
 
 		await updateGuestById({
 			id: GuestId,
@@ -82,7 +77,7 @@ const createQuestionSocketHandler = async (data, emit, socket) => {
 			isAnonymous,
 		});
 
-		reqData.id = newData.get({plain: true}).id;
+		reqData.id = newData.id;
 		if (QuestionId) {
 			reqData.QuestionId = QuestionId;
 		} else {

--- a/backend/socket_io_server/socketHandler/Question/moveQuestion.socketHandler.js
+++ b/backend/socket_io_server/socketHandler/Question/moveQuestion.socketHandler.js
@@ -1,4 +1,7 @@
-import {updateEveryState, updateQuestionById} from "../../../DB/queries/question";
+import {
+	updateEveryState,
+	updateQuestionById,
+} from "../../../DB/queries/question";
 import logger from "../../logger.js";
 
 const moveQuestionSocketHandler = async (data, emit) => {
@@ -6,8 +9,11 @@ const moveQuestionSocketHandler = async (data, emit) => {
 		const id = data.id;
 		const state = data.to;
 
-		if (id === "all") await updateEveryState("active", {state});
-		else await updateQuestionById({id, state});
+		if (id === "all") {
+			await updateEveryState("active", {state});
+		} else {
+			await updateQuestionById({id, state});
+		}
 
 		emit(data);
 	} catch (e) {

--- a/backend/socket_io_server/socketHandler/Question/toggleStar.socketHandler.js
+++ b/backend/socket_io_server/socketHandler/Question/toggleStar.socketHandler.js
@@ -1,4 +1,4 @@
-import {updateIsStared} from "../../../DB/queries/question";
+import {updateQuestionIsStared} from "../../../DB/queries/question";
 import logger from "../../logger.js";
 
 const toggleStarSocketHandler = async (data, emit) => {
@@ -6,7 +6,7 @@ const toggleStarSocketHandler = async (data, emit) => {
 		const from = data.from[0];
 		const to = data.to[0];
 
-		await updateIsStared(from, to);
+		await updateQuestionIsStared({from: from.id, to: to.id});
 		emit(to);
 	} catch (e) {
 		logger.error(e);

--- a/backend/socket_io_server/socketHandler/emoji/addEmoji.socketHandler.js
+++ b/backend/socket_io_server/socketHandler/emoji/addEmoji.socketHandler.js
@@ -4,7 +4,7 @@ const moveQuestionSocketHandler = async (data, emit) => {
 	const {GuestId, name, EventId, QuestionId} = data;
 	const res = await createEmoji({GuestId, name, EventId, QuestionId});
 
-	emit(res.get({plain: true}));
+	emit(res);
 };
 
 const eventName = "questionEmoji/create";

--- a/backend/socket_io_server/socketHandler/like/like.socketHandler.js
+++ b/backend/socket_io_server/socketHandler/like/like.socketHandler.js
@@ -2,11 +2,9 @@ import {createLike} from "../../../DB/queries/like.js";
 
 const handler = async (data, emit) => {
 	const {GuestId, QuestionId} = data;
-	const result = await createLike(GuestId, QuestionId);
+	const result = await createLike({GuestId, QuestionId});
 
-	const res = result.get({plain: true});
-
-	emit(res);
+	emit(result);
 };
 
 const eventName = "questionLike/create";

--- a/backend/spec/DB/queries/QuestionQuery.test.js
+++ b/backend/spec/DB/queries/QuestionQuery.test.js
@@ -1,79 +1,240 @@
-import {describe, it} from "mocha";
+import assert from "assert";
+import {afterEach, before, beforeEach, describe, it} from "mocha";
 import {
 	createQuestion,
 	deleteQuestionById,
 	getQuestionByGuestId,
+	getQuestionById,
 	getQuestionReplyByEventId,
 	getQuestionsByEventId,
 	updateQuestionById,
+	updateQuestionIsStared,
 } from "../../../DB/queries/question.js";
-
-
-function QueryExpectMoreThanOne(result) {
-	if (result.length === 0) {
-		throw Error("result expect more than one but not");
-	}
-}
+import models from "../../../DB/models";
 
 describe("questions query api", () => {
-	let newId = null;
-
-	it("should able to get by event id", async () => {
-		const eventId = 1;
-		const res = await getQuestionsByEventId(eventId);
-
-		QueryExpectMoreThanOne(res);
-	}).timeout(1000);
-
-	it("should able to get question reply by event id", async () => {
-		const eventId = 1;
-		const res = await getQuestionReplyByEventId(eventId);
-
-		QueryExpectMoreThanOne(res);
-	}).timeout(1000);
-
-	it("should able to get question EventCodeAndGuestId", async () => {
-		const res = await getQuestionsByEventId("u959", 22);
-
-		QueryExpectMoreThanOne(res);
+	before(async () => {
+		await models.sequelize.sync();
 	});
 
-	it("should able to get by event id", async () => {
-		const eventId = 2;
-		const res = await getQuestionsByEventId(eventId);
-
-		QueryExpectMoreThanOne(res);
+	beforeEach(async () => {
+		await models.Question.destroy({where: {}, truncate: true});
 	});
 
-	it("should able to get by guest id", async () => {
-		const eventId = 17;
-		const res = await getQuestionByGuestId(eventId);
-
-		QueryExpectMoreThanOne(res);
+	afterEach(async () => {
+		await models.Question.destroy({where: {}, truncate: true});
 	});
 
 	it("should able to create question", async () => {
-		const eventId = 2;
-		const guestId = 17;
+		// given
+		const EventId = null;
+		const GuestId = null;
+		const QuestionId = null;
 		const content = "question question";
-		const res = await createQuestion(eventId, content, guestId);
 
-		newId = res.dataValues.id;
-		QueryExpectMoreThanOne(res);
+		// when
+		const res = await createQuestion({
+			EventId,
+			content,
+			GuestId,
+			QuestionId,
+		});
+
+		// than
+		assert(typeof res === "object");
+		assert.equal(res.EventId, EventId);
+		assert.equal(res.GuestId, GuestId);
+		assert.equal(res.content, content);
+		assert.equal(res.state, "active");
+		assert(typeof res.createdAt !== "undefined");
+		assert(typeof res.updatedAt !== "undefined");
+	});
+
+	it("should able to get by event id", async () => {
+		// given
+		const EventId = null;
+		const GuestId = null;
+		const QuestionId = null;
+		const content = "question question";
+
+		const question = await createQuestion({
+			EventId,
+			content,
+			GuestId,
+			QuestionId,
+		});
+
+		// when
+		const res = await getQuestionsByEventId(EventId);
+
+		// than
+		assert(res.length > 0);
+		assert.deepStrictEqual(res[0], question);
+	});
+
+	it("should able to get question reply by event id", async () => {
+		// given
+		const EventId = null;
+		const GuestId = null;
+		const QuestionId = null;
+		const content = "question question";
+
+		const question = await createQuestion({
+			EventId,
+			content,
+			GuestId,
+			QuestionId,
+		});
+
+		const reply1 = await createQuestion({
+			EventId,
+			content,
+			GuestId,
+			QuestionId: question.id,
+		});
+
+		// when
+		const res = await getQuestionReplyByEventId(EventId);
+
+		// than
+		assert(res.length > 0);
+		assert.deepStrictEqual(res[0], reply1);
+	});
+
+	it("should able to get by guest id", async () => {
+		// given
+		const EventId = null;
+		const GuestId = null;
+		const QuestionId = null;
+		const content = "question question";
+
+		const question = await createQuestion({
+			EventId,
+			content,
+			GuestId,
+			QuestionId,
+		});
+
+		// when
+		const res = await getQuestionByGuestId(GuestId);
+
+		// than
+		assert(res.length > 0);
+		assert.deepStrictEqual(res[0], question);
 	});
 
 	it("should able to delete questionById", async () => {
-		const res = await deleteQuestionById(newId);
+		// given
+		const EventId = null;
+		const GuestId = null;
+		const QuestionId = null;
+		const content = "question question";
 
-		QueryExpectMoreThanOne(res);
+		const question = await createQuestion({
+			EventId,
+			content,
+			GuestId,
+			QuestionId,
+		});
+
+		// when
+		const res = await deleteQuestionById(question.id);
+
+		assert(res > 0);
+
+		const ret = await models.Question.findOne({where: {id: question.id}});
+
+		assert.equal(ret, null);
 	});
 
 	it("should able to update question by id", async () => {
+		// given
+		const EventId = null;
+		const GuestId = null;
+		const QuestionId = null;
+		const content = "question question";
+
+		const question = await createQuestion({
+			EventId,
+			content,
+			GuestId,
+			QuestionId,
+		});
+		const newContent = "new new content";
+
+		// when
 		const res = await updateQuestionById({
-			content: "question question",
-			id: newId,
+			content: newContent,
+			id: question.id,
 		});
 
-		QueryExpectMoreThanOne(res);
+		assert(res > 0);
+
+		const ret = (
+			await models.Question.findOne({where: {id: question.id}})
+		).get({plain: true});
+
+		assert.equal(ret.content, newContent);
+	});
+
+	it("should able to updateQuestionIsStared", async () => {
+		// given
+		const EventId = null;
+		const GuestId = null;
+		const QuestionId = null;
+		const content = "question question";
+
+		const question1 = await createQuestion({
+			EventId,
+			content,
+			GuestId,
+			QuestionId,
+		});
+
+		const question2 = await createQuestion({
+			EventId,
+			content,
+			GuestId,
+			QuestionId,
+		});
+
+		// when
+		await updateQuestionIsStared({
+			from: question1.id,
+			to: question2.id,
+		});
+
+		// than
+		const q1 = await getQuestionById(question1.id);
+		const q2 = await getQuestionById(question2.id);
+
+		assert.equal(q1.isStared, false);
+		assert.equal(q2.isStared, true);
+	});
+
+	it("should able to getQuestionById", async () => {
+		// given
+		const EventId = null;
+		const GuestId = null;
+		const QuestionId = null;
+		const content = "question question";
+
+		const createdQuestion = await createQuestion({
+			EventId,
+			content,
+			GuestId,
+			QuestionId,
+		});
+
+		// when
+		const question = await getQuestionById(createdQuestion.id);
+
+		// than
+		assert.deepStrictEqual(createdQuestion, question);
+	});
+
+	it("should able to updateEveryState", async () => {
+		// todo implement me
+		assert(false);
 	});
 });

--- a/backend/spec/DB/queries/emojiQuery.test.js
+++ b/backend/spec/DB/queries/emojiQuery.test.js
@@ -33,9 +33,9 @@ describe("emoji query api", () => {
 
 	it("should able to create emoji", async () => {
 		// given
-		const GuestId = 1;
-		const QuestionId = 40;
-		const name = "234234";
+		const GuestId = null;
+		const QuestionId = null;
+		const name = "name";
 
 		// when
 		const real = (await createEmoji({GuestId, name, QuestionId}))
@@ -53,9 +53,9 @@ describe("emoji query api", () => {
 
 	it("should able to delete emoji by id", async () => {
 		// given
-		const GuestId = 1;
-		const QuestionId = 40;
-		const name = "234234";
+		const GuestId = null;
+		const QuestionId = null;
+		const name = "name";
 		const EventId = undefined;
 
 		const id = (await Emoji.create({GuestId, QuestionId, name, EventId}))
@@ -77,8 +77,8 @@ describe("emoji query api", () => {
 
 	it("should able to delete emoji by  GuestId, name, QuestionId ", async () => {
 		// given
-		const GuestId = 1;
-		const QuestionId = 40;
+		const GuestId = null;
+		const QuestionId = null;
 		const name = "234234";
 		const EventId = undefined;
 
@@ -100,9 +100,9 @@ describe("emoji query api", () => {
 
 	it("should able to find did i picked emoji list", async () => {
 		// given
-		const GuestId = 34;
+		const GuestId = null;
 		const name = "point_up";
-		const QuestionId = 33;
+		const QuestionId = null;
 		const EventId = undefined;
 
 		await Emoji.create({GuestId, QuestionId, name, EventId});
@@ -121,9 +121,9 @@ describe("emoji query api", () => {
 
 	it("should able to get count of emoji By question and name", async () => {
 		// given
-		const QuestionId = 34;
+		const QuestionId = null;
 		const name = "point_up";
-		const GuestId = 34;
+		const GuestId = null;
 
 		await Emoji.create({QuestionId, name, GuestId});
 
@@ -140,10 +140,10 @@ describe("emoji query api", () => {
 
 	it("should able to find emoji count by eventId group by QuestionId", async () => {
 		// given
-		const QuestionId = 34;
+		const QuestionId = null;
 		const name = "point_up";
-		const EventId = 2;
-		const GuestId = 34;
+		const EventId = null;
+		const GuestId = null;
 
 		await Emoji.create({QuestionId, name, GuestId, EventId});
 
@@ -159,10 +159,10 @@ describe("emoji query api", () => {
 
 	it("should able to get emoji pick", async () => {
 		// given
-		const QuestionId = 34;
+		const QuestionId = null;
 		const name = "point_up";
-		const EventId = 2;
-		const GuestId = 34;
+		const EventId = null;
+		const GuestId = null;
 
 		await Emoji.create({QuestionId, name, GuestId, EventId});
 

--- a/backend/spec/DB/queries/emojiQuery.test.js
+++ b/backend/spec/DB/queries/emojiQuery.test.js
@@ -27,10 +27,6 @@ describe("emoji query api", () => {
 		});
 	});
 
-	it("should able to use Emoji models", async () => {
-		await Emoji.findAll({limit: 1});
-	});
-
 	it("should able to create emoji", async () => {
 		// given
 		const GuestId = null;
@@ -38,8 +34,7 @@ describe("emoji query api", () => {
 		const name = "name";
 
 		// when
-		const real = (await createEmoji({GuestId, name, QuestionId}))
-			.dataValues;
+		const real = await createEmoji({GuestId, name, QuestionId});
 
 		// than
 		const id = real.id;
@@ -58,8 +53,7 @@ describe("emoji query api", () => {
 		const name = "name";
 		const EventId = undefined;
 
-		const id = (await Emoji.create({GuestId, QuestionId, name, EventId}))
-			.dataValues.id;
+		const {id} = await createEmoji({GuestId, QuestionId, name, EventId});
 
 		// when
 		const real = await deleteEmojiById(id);
@@ -88,9 +82,7 @@ describe("emoji query api", () => {
 		const real = await deleteEmojiBy({name, QuestionId, GuestId});
 
 		// than
-		const expected = 0;
-
-		assert(real > expected);
+		assert(real === 1);
 		// todo more assert
 
 		const res = await Emoji.findOne({where: {name, QuestionId, GuestId}});
@@ -108,9 +100,7 @@ describe("emoji query api", () => {
 		await Emoji.create({GuestId, QuestionId, name, EventId});
 
 		// when
-		let real = await getDidIPicked({name, GuestId, QuestionId});
-
-		real = real.map(x => x.get({plain: true}));
+		const real = await getDidIPicked({name, GuestId, QuestionId});
 
 		// than
 		assert(real.length > 0);
@@ -131,7 +121,6 @@ describe("emoji query api", () => {
 		const real = await getEmojiCountBy({name, QuestionId});
 
 		// than
-
 		// todo more assert
 		assert(real > 0);
 
@@ -167,9 +156,7 @@ describe("emoji query api", () => {
 		await Emoji.create({QuestionId, name, GuestId, EventId});
 
 		// when
-		let real = await getEmojiPick({EventId, GuestId});
-
-		real = real.map(x => x.get({plain: true}));
+		const real = await getEmojiPick({EventId, GuestId});
 
 		// than
 		assert(real.length > 0);

--- a/backend/spec/DB/queries/eventQuery.test.js
+++ b/backend/spec/DB/queries/eventQuery.test.js
@@ -1,7 +1,11 @@
+import assert from "assert";
 import {before, describe, it} from "mocha";
 import {
 	createEvent,
+	getAllEvents,
 	getEventByEventCode,
+	getEventById,
+	getEventOptionByEventId,
 	getEventsByHostId,
 	updateEventById,
 } from "../../../DB/queries/event.js";
@@ -12,31 +16,73 @@ describe("event query api", () => {
 		await models.sequelize.sync();
 	});
 
+	it("be should able to find all events", async () => {
+		const eventCode = "event code";
+		const eventName = "event name";
+		const HostId = null;
+
+		await createEvent({eventCode, HostId, eventName});
+
+		const res = await getAllEvents();
+
+		assert(Array.isArray(res));
+		assert(res.length > 0);
+	});
+
 	it("be able to createQuestion", async () => {
-		const eventCode = "new code";
-		const content = "test content";
-		const GuestId = 1;
+		const eventCode = "event code";
+		const eventName = "event name";
+		const HostId = null;
 
-		await createEvent({eventCode, content, GuestId});
-		// todo add assertion
+		const res = await createEvent({eventCode, HostId, eventName});
+
+		assert(typeof res === "object");
+		assert(res.id > 0);
+		assert.equal(res.eventCode, eventCode);
+		assert.equal(res.eventName, eventName);
+		assert.equal(res.HostId, HostId);
+		assert(res.isLive !== undefined);
+		assert(res.moderationOption !== undefined);
+		assert(res.startAt !== undefined);
+		assert(res.endAt !== undefined);
+		assert(res.createdAt !== undefined);
+		assert(res.updatedAt !== undefined);
 	});
 
-	it("be able to getEventByEventCode", async () => {
-		const eventCode = "k9me";
+	it("be able to find event by id", async () => {
+		const oldData = {
+			eventName: "event name2",
+			eventCode: "event code2",
+			HostId: null,
+			moderationOption: true,
+			replyOption: true,
+			startAt: new Date(),
+			endAt: new Date(),
+		};
+		const oldEvent = await createEvent(oldData);
+		const id = oldEvent.id;
 
-		await getEventByEventCode(eventCode);
-		// todo add assertion
+		const event = await getEventById(id);
+
+		assert.equal(event.id, id);
+		assert.equal(event.eventName, oldData.eventName);
+		assert.equal(event.eventCode, oldData.eventCode);
+		assert(event.isLive !== undefined);
+		assert(event.moderationOption !== undefined);
+		assert(event.startAt !== undefined);
+		assert(event.endAt !== undefined);
+		assert(event.createdAt !== undefined);
+		assert(event.updatedAt !== undefined);
 	});
 
-	it("be able to getEventsByHostId", async () => {
-		const hostId = 1;
+	it("be able to return null when can not find event by id", async () => {
+		const event = await getEventById(4444);
 
-		await getEventsByHostId(hostId);
-		// todo add assertion
+		assert(event === null);
 	});
 
 	it("be able to updateEventById", async () => {
-		const EventId = 1;
+		const id = 1;
 		const newValue = {
 			eventCode: "15125",
 			moderationOption: true,
@@ -45,7 +91,99 @@ describe("event query api", () => {
 			endAt: new Date(),
 		};
 
-		await updateEventById({EventId, newValue});
-		// todo add assertion
+		const res = await updateEventById({id, ...newValue});
+
+		assert(typeof res === "number");
+		assert(res > 0);
+	});
+
+	it("be able to getEventByEventCode", async () => {
+		const oldData = {
+			eventName: "event name2",
+			eventCode: "event code2",
+			HostId: null,
+			moderationOption: true,
+			replyOption: true,
+			startAt: new Date(),
+			endAt: new Date(),
+		};
+		const oldEvent = await createEvent(oldData);
+		const id = oldEvent.id;
+
+		const event = await getEventByEventCode(oldData.eventCode);
+
+		assert.equal(event.id, id);
+		assert.equal(event.eventName, oldData.eventName);
+		assert.equal(event.eventCode, oldData.eventCode);
+		assert(event.isLive !== undefined);
+		assert(event.moderationOption !== undefined);
+		assert(event.startAt !== undefined);
+		assert(event.endAt !== undefined);
+		assert(event.createdAt !== undefined);
+		assert(event.updatedAt !== undefined);
+	});
+
+	it("be able to return null when can not getEventByEventCode", async () => {
+		const eventCode = "0000";
+
+		const res = await getEventByEventCode(eventCode);
+
+		assert(res === null);
+	});
+
+	it("be able to getEventsByHostId", async () => {
+		const oldData = {
+			eventName: "event name3",
+			eventCode: "event code3",
+			HostId: null,
+			moderationOption: true,
+			replyOption: true,
+			startAt: new Date(),
+			endAt: new Date(),
+		};
+
+		await createEvent(oldData);
+
+		const events = await getEventsByHostId(oldData.HostId);
+
+		assert(events.length > 0);
+	});
+
+	it("be able to getEventOptionByEventId", async () => {
+		const oldData = {
+			eventName: "event name3",
+			eventCode: "event code3",
+			HostId: null,
+			moderationOption: true,
+			replyOption: true,
+			startAt: new Date(),
+			endAt: new Date(),
+		};
+		const oldEvent = await createEvent(oldData);
+		const id = oldEvent.id;
+
+		const event = await getEventOptionByEventId(id);
+
+		assert.equal(event.moderationOption, oldEvent.moderationOption);
+		assert.equal(event.replyOption, oldEvent.replyOption);
+	});
+
+	it("be able to return null when can not getEventOptionByEventId", async () => {
+		const oldData = {
+			eventName: "event name3",
+			eventCode: "event code3",
+			HostId: null,
+			moderationOption: true,
+			replyOption: true,
+			startAt: new Date(),
+			endAt: new Date(),
+		};
+
+		await createEvent(oldData);
+		const id = 7777;
+
+		const event = await getEventOptionByEventId(id);
+
+		assert.equal(event, null);
 	});
 });

--- a/backend/spec/DB/queries/eventQuery.test.js
+++ b/backend/spec/DB/queries/eventQuery.test.js
@@ -16,7 +16,7 @@ describe("event query api", () => {
 		await models.sequelize.sync();
 	});
 
-	it("be should able to find all events", async () => {
+	it("should be able to find all events", async () => {
 		const eventCode = "event code";
 		const eventName = "event name";
 		const HostId = null;
@@ -29,7 +29,7 @@ describe("event query api", () => {
 		assert(res.length > 0);
 	});
 
-	it("be able to createQuestion", async () => {
+	it("should be able to create event", async () => {
 		const eventCode = "event code";
 		const eventName = "event name";
 		const HostId = null;
@@ -49,7 +49,7 @@ describe("event query api", () => {
 		assert(res.updatedAt !== undefined);
 	});
 
-	it("be able to find event by id", async () => {
+	it("should be able to find event by id", async () => {
 		const oldData = {
 			eventName: "event name2",
 			eventCode: "event code2",
@@ -75,13 +75,13 @@ describe("event query api", () => {
 		assert(event.updatedAt !== undefined);
 	});
 
-	it("be able to return null when can not find event by id", async () => {
+	it("should be able to return null when can not find event by id", async () => {
 		const event = await getEventById(4444);
 
 		assert(event === null);
 	});
 
-	it("be able to updateEventById", async () => {
+	it("should be able to updateEventById", async () => {
 		const id = 1;
 		const newValue = {
 			eventCode: "15125",
@@ -97,7 +97,7 @@ describe("event query api", () => {
 		assert(res > 0);
 	});
 
-	it("be able to getEventByEventCode", async () => {
+	it("should be able to getEventByEventCode", async () => {
 		const oldData = {
 			eventName: "event name2",
 			eventCode: "event code2",
@@ -123,7 +123,7 @@ describe("event query api", () => {
 		assert(event.updatedAt !== undefined);
 	});
 
-	it("be able to return null when can not getEventByEventCode", async () => {
+	it("should be able to return null when can not getEventByEventCode", async () => {
 		const eventCode = "0000";
 
 		const res = await getEventByEventCode(eventCode);
@@ -131,7 +131,7 @@ describe("event query api", () => {
 		assert(res === null);
 	});
 
-	it("be able to getEventsByHostId", async () => {
+	it("should be able to getEventsByHostId", async () => {
 		const oldData = {
 			eventName: "event name3",
 			eventCode: "event code3",
@@ -149,7 +149,7 @@ describe("event query api", () => {
 		assert(events.length > 0);
 	});
 
-	it("be able to getEventOptionByEventId", async () => {
+	it("should be able to getEventOptionByEventId", async () => {
 		const oldData = {
 			eventName: "event name3",
 			eventCode: "event code3",
@@ -168,7 +168,7 @@ describe("event query api", () => {
 		assert.equal(event.replyOption, oldEvent.replyOption);
 	});
 
-	it("be able to return null when can not getEventOptionByEventId", async () => {
+	it("should be able to return null when can not getEventOptionByEventId", async () => {
 		const oldData = {
 			eventName: "event name3",
 			eventCode: "event code3",

--- a/backend/spec/DB/queries/eventQuery.test.js
+++ b/backend/spec/DB/queries/eventQuery.test.js
@@ -1,12 +1,17 @@
-import {describe, it} from "mocha";
+import {before, describe, it} from "mocha";
 import {
 	createEvent,
 	getEventByEventCode,
 	getEventsByHostId,
 	updateEventById,
 } from "../../../DB/queries/event.js";
+import models from "../../../DB/models";
 
 describe("event query api", () => {
+	before(async () => {
+		await models.sequelize.sync();
+	});
+
 	it("be able to createQuestion", async () => {
 		const eventCode = "new code";
 		const content = "test content";

--- a/backend/spec/DB/queries/guestQuery.test.js
+++ b/backend/spec/DB/queries/guestQuery.test.js
@@ -1,43 +1,113 @@
+import assert from "assert";
 import {before, describe, it} from "mocha";
 import {
 	createGuest,
 	getGuestByEventId,
+	getGuestByGuestSid,
 	getGuestById,
+	isExistGuest,
 	updateGuestById,
 } from "../../../DB/queries/guest.js";
 import models from "../../../DB/models";
 
 describe("guest query api", () => {
-	const newId = null;
-
 	before(async () => {
 		await models.sequelize.sync();
 	});
 
-	it("should able to create guest", async () => {
+	it("should be able to create guest", async () => {
+		// given
 		const EventId = null;
 
-		await createGuest(EventId);
+		// when
+		const guest = await createGuest(EventId);
 
-		// todo add assertion
+		// than
+		assert(guest.id > 0);
+		assert(guest.name !== null);
+		assert(guest.guestSid !== null);
+		assert(typeof guest.guestSid === "string");
+		assert(guest.email === null);
+		assert(guest.isAnonymous === true);
+		assert(guest.email === null);
 	});
 
-	it("should able to update guest", async () => {
-		const name = "name";
+	it("should be able to return null when can not getGuestByGuestSid", async () => {
+		const res = await getGuestByGuestSid("234234");
 
-		await updateGuestById({id: newId, name});
-		// todo add assertion
+		assert(res === null);
+	});
+
+	it("should be able to getGuestByGuestSid", async () => {
+		// given
+		const EventId = null;
+		const guest = await createGuest(EventId);
+
+		// when
+		const res = await getGuestByGuestSid(guest.guestSid);
+
+		// than
+		assert.deepStrictEqual(guest, res);
 	});
 
 	it("should able to get guest by Id", async () => {
-		await getGuestById(newId);
-		// todo add assertion
+		// given
+		const EventId = null;
+		const guest = await createGuest(EventId);
+
+		// when
+		const res = await getGuestById(guest.id);
+
+		// than
+		assert.deepStrictEqual(guest, res);
+	});
+
+	it("should able to return when can not get guest by Id", async () => {
+		// given
+		const id = 1236123;
+
+		// when
+		const res = await getGuestById(id);
+
+		// than
+		assert(res === null);
+	});
+
+	it("should able to update guest", async () => {
+		// given
+		const EventId = null;
+		const guest = await createGuest(EventId);
+		const name = "newName";
+
+		// when
+		const res = await updateGuestById({id: guest.id, name});
+
+		// than
+		assert(res > 0);
 	});
 
 	it("should able to get guest by EventId", async () => {
-		const EventId = 3;
+		// given
+		const EventId = null;
 
-		await getGuestByEventId(EventId);
-		// todo add assertion
+		// when
+		const res = await getGuestByEventId(EventId);
+
+		// then
+		assert(res.length > 0);
+	});
+
+	it("should able to isExistGuest", async () => {
+		// given
+		const EventId = null;
+		const guest = await createGuest(EventId);
+		const guestSid = guest.guestSid;
+
+		// when
+		const res = await isExistGuest(guestSid);
+
+		// then
+		assert(typeof res === "boolean");
+		assert(res === true);
 	});
 });

--- a/backend/spec/DB/queries/guestQuery.test.js
+++ b/backend/spec/DB/queries/guestQuery.test.js
@@ -1,19 +1,23 @@
-import {describe, it} from "mocha";
+import {before, describe, it} from "mocha";
 import {
 	createGuest,
 	getGuestByEventId,
 	getGuestById,
 	updateGuestById,
 } from "../../../DB/queries/guest.js";
+import models from "../../../DB/models";
 
 describe("guest query api", () => {
 	const newId = null;
 
-	it("should able to create guest", async () => {
-		const EventId = 3;
-		const name = "name";
+	before(async () => {
+		await models.sequelize.sync();
+	});
 
-		await createGuest(name, EventId);
+	it("should able to create guest", async () => {
+		const EventId = null;
+
+		await createGuest(EventId);
 
 		// todo add assertion
 	});

--- a/backend/spec/DB/queries/hashtagQuery.test.js
+++ b/backend/spec/DB/queries/hashtagQuery.test.js
@@ -1,16 +1,21 @@
-import {describe, it} from "mocha";
+import {before, describe, it} from "mocha";
 import {
 	createHashtag,
 	deleteHashTagById,
-	updateHashtagById,
 	getHashtagByEventId,
+	updateHashtagById,
 } from "../../../DB/queries/hashtag.js";
+import models from "../../../DB/models";
 
 describe("hashtag query api", () => {
 	let newId = null;
 
+	before(async () => {
+		await models.sequelize.sync();
+	});
+
 	it("should able to create hashtag", async () => {
-		const EventId = 3;
+		const EventId = null;
 		const name = "name";
 
 		const res = await createHashtag({EventId, name});
@@ -19,7 +24,7 @@ describe("hashtag query api", () => {
 	});
 
 	it("should able to update hashtag by id", async () => {
-		await updateHashtagById(newId);
+		await updateHashtagById({id: newId, name: "newName"});
 	});
 
 	it("should able to delete hashtag by id", async () => {

--- a/backend/spec/DB/queries/hashtagQuery.test.js
+++ b/backend/spec/DB/queries/hashtagQuery.test.js
@@ -1,41 +1,96 @@
+import assert from "assert";
 import {before, describe, it} from "mocha";
 import {
 	createHashtag,
 	deleteHashTagById,
 	getHashtagByEventId,
+	getHashtagByEventIds,
 	updateHashtagById,
 } from "../../../DB/queries/hashtag.js";
 import models from "../../../DB/models";
+import {createEvent} from "../../../DB/queries/event.js";
 
 describe("hashtag query api", () => {
-	let newId = null;
-
 	before(async () => {
 		await models.sequelize.sync();
 	});
 
 	it("should able to create hashtag", async () => {
+		// given
 		const EventId = null;
 		const name = "name";
 
-		const res = await createHashtag({EventId, name});
+		// when
+		const hashtag = await createHashtag({EventId, name});
 
-		newId = res.dataValues.id;
+		// than
+		assert(hashtag.id > 0);
+		assert.equal(hashtag.name, name);
+		assert.equal(hashtag.EventId, EventId);
 	});
 
 	it("should able to update hashtag by id", async () => {
-		await updateHashtagById({id: newId, name: "newName"});
+		// given
+		const EventId = null;
+		const name = "name";
+		const hashtag = await createHashtag({EventId, name});
+
+		// when
+		const res = await updateHashtagById({id: hashtag.id, name: "newName"});
+
+		// than
+		assert(res > 0);
 	});
 
 	it("should able to delete hashtag by id", async () => {
-		await deleteHashTagById(newId);
+		// given
+		const EventId = null;
+		const name = "name";
+		const hashtag = await createHashtag({EventId, name});
+
+		// when
+		const res = await deleteHashTagById(hashtag.id);
+
+		// than
+		assert(res > 0);
 	});
 
 	it("should able to get hashtag by event id", async () => {
-		const EventId = 3;
+		// given
+		const EventId = null;
+		const name = "name";
 
+		await createHashtag({EventId, name});
+
+		// when
 		const res = await getHashtagByEventId(EventId);
 
-		await res.map(x => x.get({plain: true}));
+		// than
+		assert(res.length > 0);
+	});
+
+	it("should able to get hashtag by event ids", async () => {
+		// given
+		const oldData = {
+			eventName: "event name2",
+			eventCode: "event code2",
+			HostId: null,
+			moderationOption: true,
+			replyOption: true,
+			startAt: new Date(),
+			endAt: new Date(),
+		};
+		const oldEvent = await createEvent(oldData);
+		const EventId = oldEvent.id;
+		const name = "name";
+
+		await createHashtag({EventId, name});
+		await createHashtag({EventId, name});
+
+		// when
+		const res = await getHashtagByEventIds([EventId]);
+
+		// than
+		assert(res.length > 0);
 	});
 });

--- a/backend/spec/DB/queries/hostQuery.test.js
+++ b/backend/spec/DB/queries/hostQuery.test.js
@@ -1,6 +1,10 @@
 import {before, describe, it} from "mocha";
 import assert from "assert";
-import {findOrCreateHostByOAuth} from "../../../DB/queries/host.js";
+import {
+	findHostByOAuthId,
+	findOrCreateHostByOAuth,
+	isExistHostOAuthId,
+} from "../../../DB/queries/host.js";
 import models from "../../../DB/models";
 
 describe("host query api", () => {
@@ -25,5 +29,56 @@ describe("host query api", () => {
 		assert.equal(host.name, name);
 		assert.equal(host.image, image);
 		assert.equal(host.oauthId, oauthId);
+	});
+
+	it("be able to find host by oauth id", async () => {
+		// given
+		const oauthId = "1234";
+		const image = "image";
+		const name = "name";
+		const email = "email";
+		const existHost = await findOrCreateHostByOAuth({
+			oauthId,
+			image,
+			email,
+			name,
+		});
+
+		// when
+		const host = await findHostByOAuthId(oauthId);
+
+		// than
+		assert.deepStrictEqual(existHost, host);
+	});
+
+	it("be able to return null when can not find host by oauth id", async () => {
+		// given
+		const oauthId = "not exist";
+
+		// when
+		const host = await findHostByOAuthId(oauthId);
+
+		// than
+		assert(host === null);
+	});
+
+	it("be able to check is exist host oauth id", async () => {
+		// given
+		const oauthId = "1234";
+		const image = "image";
+		const name = "name";
+		const email = "email";
+		await findOrCreateHostByOAuth({
+			oauthId,
+			image,
+			email,
+			name,
+		});
+
+		// when
+		const isExist = await isExistHostOAuthId(oauthId);
+
+		assert(typeof isExist === "boolean");
+		assert(isExist === true);
 	});
 });

--- a/backend/spec/DB/queries/hostQuery.test.js
+++ b/backend/spec/DB/queries/hostQuery.test.js
@@ -1,8 +1,13 @@
-import {describe, it} from "mocha";
+import {before, describe, it} from "mocha";
 import assert from "assert";
 import {findHostByAuthId} from "../../../DB/queries/host.js";
+import models from "../../../DB/models";
 
 describe("host query api", () => {
+	before(async () => {
+		await models.sequelize.sync();
+	});
+
 	it("be able to findHostByAuthId", async () => {
 		const authId = "1234";
 		const host = await findHostByAuthId(authId);

--- a/backend/spec/DB/queries/hostQuery.test.js
+++ b/backend/spec/DB/queries/hostQuery.test.js
@@ -1,6 +1,6 @@
 import {before, describe, it} from "mocha";
 import assert from "assert";
-import {findHostByAuthId} from "../../../DB/queries/host.js";
+import {findOrCreateHostByOAuth} from "../../../DB/queries/host.js";
 import models from "../../../DB/models";
 
 describe("host query api", () => {
@@ -8,10 +8,22 @@ describe("host query api", () => {
 		await models.sequelize.sync();
 	});
 
-	it("be able to findHostByAuthId", async () => {
-		const authId = "1234";
-		const host = await findHostByAuthId(authId);
+	it("be able to find or create host by oauthId", async () => {
+		const oauthId = "1234";
+		const image = "image";
+		const name = "name";
+		const email = "email";
+		const host = await findOrCreateHostByOAuth({
+			oauthId,
+			image,
+			email,
+			name,
+		});
 
-		assert.deepStrictEqual(host, false);
+		assert(host.id > 0);
+		assert.equal(host.email, email);
+		assert.equal(host.name, name);
+		assert.equal(host.image, image);
+		assert.equal(host.oauthId, oauthId);
 	});
 });

--- a/backend/spec/DB/queries/likeQuery.test.js
+++ b/backend/spec/DB/queries/likeQuery.test.js
@@ -1,4 +1,4 @@
-import {describe, it} from "mocha";
+import {before, describe, it} from "mocha";
 import {
 	createLike,
 	deleteLikeById,
@@ -7,12 +7,17 @@ import {
 	getLikesByGuestId,
 	getLikesByQuestionId,
 } from "../../../DB/queries/like.js";
+import models from "../../../DB/models";
 
 describe("like query api", () => {
 	let newId = null;
 
+	before(async () => {
+		await models.sequelize.sync();
+	});
+
 	it("should able to create Like", async () => {
-		const eventId = 2;
+		const eventId = null;
 		const res = await createLike(eventId);
 
 		newId = res.dataValues.id;
@@ -25,29 +30,29 @@ describe("like query api", () => {
 	});
 
 	it("should able to get likes by guest id", async () => {
-		const guestId = 17;
+		const guestId = null;
 
 		await getLikesByGuestId(guestId);
 		// todo add assertion
 	});
 
 	it("should able to get likes question id", async () => {
-		const questionId = 34;
+		const questionId = null;
 
 		await getLikesByQuestionId(questionId);
 		// todo add assertion
 	});
 
 	it("should able to get like count By Question", async () => {
-		const questionId = 34;
+		const questionId = null;
 
 		await getLikeCountByQuestion(questionId);
 		// todo add assertion
 	});
 
 	it("should able to get didILiked", async () => {
-		const QuestionId = 11;
-		const GuestId = 58;
+		const QuestionId = null;
+		const GuestId = null;
 
 		await getDidILikes({
 			QuestionId,

--- a/backend/spec/DB/queries/likeQuery.test.js
+++ b/backend/spec/DB/queries/likeQuery.test.js
@@ -1,63 +1,61 @@
-import {before, describe, it} from "mocha";
+import assert from "assert";
+import {before, beforeEach, describe, it} from "mocha";
 import {
 	createLike,
-	deleteLikeById,
-	getDidILikes,
-	getLikeCountByQuestion,
+	deleteLikeBy,
 	getLikesByGuestId,
-	getLikesByQuestionId,
 } from "../../../DB/queries/like.js";
 import models from "../../../DB/models";
 
 describe("like query api", () => {
-	let newId = null;
-
 	before(async () => {
 		await models.sequelize.sync();
 	});
 
+	beforeEach(async () => {
+		await models.Like.destroy({where: {}, truncate: true});
+	});
+
 	it("should able to create Like", async () => {
-		const eventId = null;
-		const res = await createLike(eventId);
-
-		newId = res.dataValues.id;
-		// todo add assertion
-	});
-
-	it("should able to delete Like", async () => {
-		await deleteLikeById(newId);
-		// todo add assertion
-	});
-
-	it("should able to get likes by guest id", async () => {
-		const guestId = null;
-
-		await getLikesByGuestId(guestId);
-		// todo add assertion
-	});
-
-	it("should able to get likes question id", async () => {
-		const questionId = null;
-
-		await getLikesByQuestionId(questionId);
-		// todo add assertion
-	});
-
-	it("should able to get like count By Question", async () => {
-		const questionId = null;
-
-		await getLikeCountByQuestion(questionId);
-		// todo add assertion
-	});
-
-	it("should able to get didILiked", async () => {
+		// given
 		const QuestionId = null;
 		const GuestId = null;
 
-		await getDidILikes({
-			QuestionId,
-			GuestId,
-		});
-		// todo add assertion
+		// when
+		const res = await createLike({QuestionId, GuestId});
+
+		// than
+
+		assert(res.id > 0);
+		assert.equal(res.GuestId, GuestId);
+		assert.equal(res.QuestionId, QuestionId);
+	});
+
+	it("should able to delete Like by ", async () => {
+		// given
+		const QuestionId = null;
+		const GuestId = null;
+
+		await createLike({QuestionId, GuestId});
+
+		// when
+		const res = await deleteLikeBy({QuestionId, GuestId});
+
+		// than
+		assert.equal(res, 1);
+	});
+
+	it("should able to get likes by guest id", async () => {
+		// given
+		const QuestionId = null;
+		const GuestId = null;
+		const like = await createLike({QuestionId, GuestId});
+
+		// when
+		const res = await getLikesByGuestId(GuestId);
+
+		// than
+		assert.equal(res.length, 1);
+		assert.deepStrictEqual(res[0], like);
 	});
 });


### PR DESCRIPTION
# 대부분의 DB query api 에 대한 단위테스트 강화 및 

* DB query api 의 unit test 보완
* DB query api 에 jsdoc 추가
* DB query api  반환타입을 plain object 또는 기본 타입이 되도록 수정

# minor 한 리펙토링
* findHostByOAuthId, isExistHostOAuthId 함수로 분리
-> 단순히 oauthId로 검색하는경우와 존재여부를 확인하는 기능으로 분리 가능하기 떄문임
