### PR TITLE
refactoring: change to es6 base sequelize model define

### DIFF
--- a/backend/DB/models/candidate.js
+++ b/backend/DB/models/candidate.js
@@ -1,34 +1,36 @@
-module.exports = (sequelize, DataTypes) => {
-	const Candidate = sequelize.define(
-		"Candidate",
-		{
-			id: {
-				allowNull: false,
-				autoIncrement: true,
-				primaryKey: true,
-				type: DataTypes.INTEGER,
-			},
-			number: {
-				type: DataTypes.INTEGER,
-			},
-			content: {
-				type: DataTypes.STRING(100),
-			},
-			createdAt: {
-				allowNull: false,
-				type: DataTypes.DATE,
-			},
-			updatedAt: {
-				allowNull: false,
-				type: DataTypes.DATE,
-			},
-		},
-		{},
-	);
+import {Model} from "sequelize";
 
-	Candidate.associate = function(models) {
-		Candidate.belongsTo(models.Poll);
-		Candidate.belongsToMany(models.Guest, {through: "Votes"});
-	};
-	return Candidate;
-};
+export default class Candidate extends Model {
+	static init(sequelize, DataTypes) {
+		return super.init(
+			{
+				id: {
+					allowNull: false,
+					autoIncrement: true,
+					primaryKey: true,
+					type: DataTypes.INTEGER,
+				},
+				number: {
+					type: DataTypes.INTEGER,
+				},
+				content: {
+					type: DataTypes.STRING(100),
+				},
+				createdAt: {
+					allowNull: false,
+					type: DataTypes.DATE,
+				},
+				updatedAt: {
+					allowNull: false,
+					type: DataTypes.DATE,
+				},
+			},
+			{sequelize, tableName: "Candidates"},
+		);
+	}
+
+	static associate(models) {
+		models.Candidate.belongsTo(models.Poll);
+		models.Candidate.belongsToMany(models.Guest, {through: "Votes"});
+	}
+}

--- a/backend/DB/models/emoji.js
+++ b/backend/DB/models/emoji.js
@@ -1,35 +1,38 @@
-module.exports = (sequelize, DataTypes) => {
-	const Emoji = sequelize.define(
-		"Emoji",
-		{
-			id: {
-				allowNull: false,
-				autoIncrement: true,
-				primaryKey: true,
-				type: DataTypes.INTEGER,
-			},
-			createdAt: {
-				allowNull: false,
-				type: DataTypes.DATE,
-			},
-			updatedAt: {
-				allowNull: false,
-				type: DataTypes.DATE,
-			},
-			name: {
-				type: DataTypes.STRING(100),
-			},
-			QuestionId: {
-				type: DataTypes.INTEGER,
-			},
-			GuestId: {
-				type: DataTypes.INTEGER,
-			},
-		},
-	);
+import {Model} from "sequelize";
 
-	Emoji.associate = function(models) {
-		Emoji.belongsTo(models.Event);
-	};
-	return Emoji;
-};
+export default class Emoji extends Model {
+	static init(sequelize, DataTypes) {
+		return super.init(
+			{
+				id: {
+					allowNull: false,
+					autoIncrement: true,
+					primaryKey: true,
+					type: DataTypes.INTEGER,
+				},
+				createdAt: {
+					allowNull: false,
+					type: DataTypes.DATE,
+				},
+				updatedAt: {
+					allowNull: false,
+					type: DataTypes.DATE,
+				},
+				name: {
+					type: DataTypes.STRING(100),
+				},
+				QuestionId: {
+					type: DataTypes.INTEGER,
+				},
+				GuestId: {
+					type: DataTypes.INTEGER,
+				},
+			},
+			{sequelize, tableName: "Emojis"},
+		);
+	}
+
+	static associate(models) {
+		models.Emoji.belongsTo(models.Event);
+	}
+}

--- a/backend/DB/models/event.js
+++ b/backend/DB/models/event.js
@@ -1,58 +1,60 @@
-module.exports = (sequelize, DataTypes) => {
-	const Event = sequelize.define(
-		"Event",
-		{
-			id: {
-				allowNull: false,
-				autoIncrement: true,
-				primaryKey: true,
-				type: DataTypes.INTEGER,
-			},
-			eventCode: {
-				type: DataTypes.STRING(10),
-			},
-			eventName: {
-				type: DataTypes.STRING(100),
-			},
-			moderationOption: {
-				type: DataTypes.BOOLEAN,
-				defaultValue: false,
-			},
-			isLive: {
-				type: DataTypes.BOOLEAN,
-				defaultValue: false,
-			},
-			replyOption: {
-				type: DataTypes.BOOLEAN,
-				defaultValue: false,
-			},
-			createdAt: {
-				allowNull: false,
-				type: DataTypes.DATE,
-			},
-			updatedAt: {
-				allowNull: false,
-				type: DataTypes.DATE,
-			},
-			startAt: {
-				allowNull: false,
-				type: DataTypes.DATE,
-			},
-			endAt: {
-				allowNull: false,
-				type: DataTypes.DATE,
-			},
-		},
-		{},
-	);
+import {Model} from "sequelize";
 
-	Event.associate = function(models) {
-		Event.hasMany(models.Guest);
-		Event.hasMany(models.Question);
-		Event.belongsTo(models.Host);
-		Event.hasMany(models.Poll);
-		Event.hasMany(models.Hashtag);
-		Event.hasMany(models.Emoji);
-	};
-	return Event;
-};
+export default class Event extends Model {
+	static init(sequelize, DataTypes) {
+		return super.init(
+			{
+				id: {
+					allowNull: false,
+					autoIncrement: true,
+					primaryKey: true,
+					type: DataTypes.INTEGER,
+				},
+				eventCode: {
+					type: DataTypes.STRING(10),
+				},
+				eventName: {
+					type: DataTypes.STRING(100),
+				},
+				moderationOption: {
+					type: DataTypes.BOOLEAN,
+					defaultValue: false,
+				},
+				isLive: {
+					type: DataTypes.BOOLEAN,
+					defaultValue: false,
+				},
+				replyOption: {
+					type: DataTypes.BOOLEAN,
+					defaultValue: false,
+				},
+				createdAt: {
+					allowNull: false,
+					type: DataTypes.DATE,
+				},
+				updatedAt: {
+					allowNull: false,
+					type: DataTypes.DATE,
+				},
+				startAt: {
+					allowNull: false,
+					type: DataTypes.DATE,
+				},
+				endAt: {
+					allowNull: false,
+					type: DataTypes.DATE,
+				},
+			},
+			{sequelize},
+		);
+	}
+
+	static associate(models) {
+		models.Event.hasMany(models.Guest);
+		models.Event.hasMany(models.Question);
+		models.Event.belongsTo(models.Host);
+		models.Event.hasMany(models.Poll);
+		models.Event.hasMany(models.Hashtag);
+		models.Event.hasMany(models.Emoji);
+	}
+}

--- a/backend/DB/models/guest.js
+++ b/backend/DB/models/guest.js
@@ -1,48 +1,51 @@
-module.exports = (sequelize, DataTypes) => {
-	const Guest = sequelize.define(
-		"Guest",
-		{
-			id: {
-				allowNull: false,
-				autoIncrement: true,
-				primaryKey: true,
-				type: DataTypes.INTEGER,
-			},
-			name: {
-				type: DataTypes.STRING(100),
-			},
-			guestSid: {
-				type: DataTypes.STRING(100),
-			},
-			createdAt: {
-				allowNull: false,
-				type: DataTypes.DATE,
-			},
-			isAnonymous: {
-				type: DataTypes.BOOLEAN,
-			},
-			updatedAt: {
-				allowNull: false,
-				type: DataTypes.DATE,
-			},
-			email: {
-				type: DataTypes.STRING(100),
-				defaultValue: null,
-			},
-			company: {
-				type: DataTypes.STRING(100),
-				defaultValue: null,
-			},
-		},
-		{},
-	);
+import {Model} from "sequelize";
 
-	Guest.associate = function(models) {
-		Guest.belongsTo(models.Event);
-		Guest.hasMany(models.Question);
-		Guest.belongsToMany(models.Candidate, {through: "Votes"});
-		Guest.hasMany(models.Like);
-		Guest.hasMany(models.Emoji);
-	};
-	return Guest;
-};
+export default class Guest extends Model {
+	static init(sequelize, DataTypes) {
+		return super.init(
+			{
+				id: {
+					allowNull: false,
+					autoIncrement: true,
+					primaryKey: true,
+					type: DataTypes.INTEGER,
+				},
+				name: {
+					type: DataTypes.STRING(100),
+				},
+				guestSid: {
+					type: DataTypes.STRING(100),
+				},
+				createdAt: {
+					allowNull: false,
+					type: DataTypes.DATE,
+				},
+				isAnonymous: {
+					type: DataTypes.BOOLEAN,
+				},
+				updatedAt: {
+					allowNull: false,
+					type: DataTypes.DATE,
+				},
+				email: {
+					type: DataTypes.STRING(100),
+					defaultValue: null,
+				},
+				company: {
+					type: DataTypes.STRING(100),
+					defaultValue: null,
+				},
+			},
+			{sequelize, tableName: "Guests"},
+		);
+	}
+
+	static associate(models) {
+		models.Guest.belongsTo(models.Event);
+		models.Guest.hasMany(models.Question);
+		models.Guest.belongsToMany(models.Candidate, {through: "Votes"});
+		models.Guest.hasMany(models.Like);
+		models.Guest.hasMany(models.Emoji);
+	}
+}
+

--- a/backend/DB/models/hashtag.js
+++ b/backend/DB/models/hashtag.js
@@ -1,30 +1,33 @@
-module.exports = (sequelize, DataTypes) => {
-	const Hashtag = sequelize.define(
-		"Hashtag",
-		{
-			id: {
-				allowNull: false,
-				autoIncrement: true,
-				primaryKey: true,
-				type: DataTypes.INTEGER,
-			},
-			name: {
-				type: DataTypes.STRING(100),
-			},
-			createdAt: {
-				allowNull: false,
-				type: DataTypes.DATE,
-			},
-			updatedAt: {
-				allowNull: false,
-				type: DataTypes.DATE,
-			},
-		},
-		{},
-	);
+import {Model} from "sequelize";
 
-	Hashtag.associate = function(models) {
-		Hashtag.belongsTo(models.Event);
-	};
-	return Hashtag;
-};
+export default class Hashtag extends Model {
+	static init(sequelize, DataTypes) {
+		return super.init(
+			{
+				id: {
+					allowNull: false,
+					autoIncrement: true,
+					primaryKey: true,
+					type: DataTypes.INTEGER,
+				},
+				name: {
+					type: DataTypes.STRING(100),
+				},
+				createdAt: {
+					allowNull: false,
+					type: DataTypes.DATE,
+				},
+				updatedAt: {
+					allowNull: false,
+					type: DataTypes.DATE,
+				},
+			},
+			{sequelize, tableName: "Hashtags"},
+		);
+	}
+
+	static associate(models) {
+		models.Hashtag.belongsTo(models.Event);
+	}
+}
+

--- a/backend/DB/models/host.js
+++ b/backend/DB/models/host.js
@@ -1,42 +1,45 @@
-module.exports = (sequelize, DataTypes) => {
-	const Host = sequelize.define(
-		"Host",
-		{
-			id: {
-				allowNull: false,
-				autoIncrement: true,
-				primaryKey: true,
-				type: DataTypes.INTEGER,
-			},
-			oauthId: {
-				type: DataTypes.STRING(100),
-			},
-			name: {
-				type: DataTypes.STRING(100),
-			},
-			email: {
-				type: DataTypes.STRING(100),
-			},
-			emailFeedBack: {
-				type: DataTypes.BOOLEAN,
-			},
-			image: {
-				type: DataTypes.TEXT,
-			},
-			createdAt: {
-				allowNull: false,
-				type: DataTypes.DATE,
-			},
-			updatedAt: {
-				allowNull: false,
-				type: DataTypes.DATE,
-			},
-		},
-		{},
-	);
+import {Model} from "sequelize";
 
-	Host.associate = function(models) {
-		Host.hasMany(models.Event);
-	};
-	return Host;
-};
+export default class Host extends Model {
+	static init(sequelize, DataTypes) {
+		return super.init(
+			{
+				id: {
+					allowNull: false,
+					autoIncrement: true,
+					primaryKey: true,
+					type: DataTypes.INTEGER,
+				},
+				oauthId: {
+					type: DataTypes.STRING(100),
+				},
+				name: {
+					type: DataTypes.STRING(100),
+				},
+				email: {
+					type: DataTypes.STRING(100),
+				},
+				emailFeedBack: {
+					type: DataTypes.BOOLEAN,
+				},
+				image: {
+					type: DataTypes.TEXT,
+				},
+				createdAt: {
+					allowNull: false,
+					type: DataTypes.DATE,
+				},
+				updatedAt: {
+					allowNull: false,
+					type: DataTypes.DATE,
+				},
+			},
+			{sequelize, tableName: "Hosts"},
+		);
+	}
+
+	static associate(models) {
+		models.Host.hasMany(models.Event);
+	}
+}
+

--- a/backend/DB/models/index.js
+++ b/backend/DB/models/index.js
@@ -7,7 +7,6 @@ const basename = path.basename(__filename);
 const env = process.env.NODE_ENV || "development";
 // change config setting *.json to *.config.js
 const config = require(path.resolve(__dirname, "../sequelize.config.js"))[env];
-const db = {};
 
 let sequelize;
 // noinspection JSUnresolvedVariable
@@ -24,32 +23,47 @@ if (config.use_env_variable) {
 		config.database,
 		config.username,
 		config.password,
-		config
+		config,
 	);
 }
 
-fs.readdirSync(__dirname)
-	.filter(file => {
-		return (
-			file.indexOf(".") !== 0 &&
-			file !== basename &&
-			file.slice(-3) === ".js"
-		);
-	})
-	.forEach(file => {
-		const model = sequelize["import"](path.join(__dirname, file));
-		db[model.name] = model;
-	});
+// import es6 base sequelize model
+// ref https://codewithhugo.com/using-es6-classes-for-sequelize-4-models/
+// pass your sequelize config here
+import Host from "./host.js";
+import Emoji from "./emoji.js";
+import Event from "./event.js";
+import Guest from "./guest.js";
+import Hashtag from "./hashtag.js";
+import Like from "./like.js";
+import Poll from "./poll.js";
+import Question from "./question.js";
+import Vote from "./vote.js";
+import Candidate from "./candidate.js";
 
-Object.keys(db).forEach(modelName => {
-	// noinspection JSUnresolvedVariable
-	if (db[modelName].associate) {
-		// noinspection JSUnresolvedVariable
-		db[modelName].associate(db);
-	}
-});
+// init all sequelize model
+const models = {
+	Host: Host.init(sequelize, Sequelize),
+	Event: Event.init(sequelize, Sequelize),
+	Emoji: Emoji.init(sequelize, Sequelize),
+	Guest: Guest.init(sequelize, Sequelize),
+	Hashtag: Hashtag.init(sequelize, Sequelize),
+	Like: Like.init(sequelize, Sequelize),
+	Poll: Poll.init(sequelize, Sequelize),
+	Question: Question.init(sequelize, Sequelize),
+	Vote: Vote.init(sequelize, Sequelize),
+	Candidate: Candidate.init(sequelize, Sequelize),
+};
 
-db.sequelize = sequelize;
-db.Sequelize = Sequelize;
+// Run `.associate` if it exists,
+// ie create relationships in the ORM
+Object.values(models)
+	.filter(model => typeof model.associate === "function")
+	.forEach(model => model.associate(models));
+
+const db = {
+	...models,
+	sequelize,
+};
 
 module.exports = db;

--- a/backend/DB/models/like.js
+++ b/backend/DB/models/like.js
@@ -1,28 +1,30 @@
-module.exports = (sequelize, DataTypes) => {
-	const Like = sequelize.define(
-		"Like",
-		{
-			id: {
-				allowNull: false,
-				autoIncrement: true,
-				primaryKey: true,
-				type: DataTypes.INTEGER,
-			},
-			createdAt: {
-				allowNull: false,
-				type: DataTypes.DATE,
-			},
-			updatedAt: {
-				allowNull: false,
-				type: DataTypes.DATE,
-			},
-		},
-		{},
-	);
+import {Model} from "sequelize";
 
-	Like.associate = function(models) {
-		Like.belongsTo(models.Question);
-		Like.belongsTo(models.Guest);
-	};
-	return Like;
-};
+export default class Like extends Model {
+	static init(sequelize, DataTypes) {
+		return super.init(
+			{
+				id: {
+					allowNull: false,
+					autoIncrement: true,
+					primaryKey: true,
+					type: DataTypes.INTEGER,
+				},
+				createdAt: {
+					allowNull: false,
+					type: DataTypes.DATE,
+				},
+				updatedAt: {
+					allowNull: false,
+					type: DataTypes.DATE,
+				},
+			},
+			{sequelize, tableName: "Likes"},
+		);
+	}
+
+	static associate(models) {
+		models.Like.belongsTo(models.Question);
+		models.Like.belongsTo(models.Guest);
+	}
+}

--- a/backend/DB/models/poll.js
+++ b/backend/DB/models/poll.js
@@ -1,46 +1,48 @@
-module.exports = (sequelize, DataTypes) => {
-	const Poll = sequelize.define(
-		"Poll",
-		{
-			id: {
-				allowNull: false,
-				autoIncrement: true,
-				primaryKey: true,
-				type: DataTypes.INTEGER,
-			},
-			pollName: {
-				type: DataTypes.STRING(100),
-			},
-			pollType: {
-				type: DataTypes.STRING(10),
-			},
-			selectionType: {
-				type: DataTypes.STRING(10),
-			},
-			allowDuplication: {
-				type: DataTypes.BOOLEAN,
-			},
-			state: {
-				type: DataTypes.STRING(10),
-			},
-			pollDate: {
-				type: DataTypes.DATE,
-			},
-			createdAt: {
-				allowNull: false,
-				type: DataTypes.DATE,
-			},
-			updatedAt: {
-				allowNull: false,
-				type: DataTypes.DATE,
-			},
-		},
-		{},
-	);
+import {Model} from "sequelize";
 
-	Poll.associate = function(models) {
-		Poll.belongsTo(models.Event);
-		Poll.hasMany(models.Candidate);
-	};
-	return Poll;
-};
+export default class Poll extends Model {
+	static init(sequelize, DataTypes) {
+		return super.init(
+			{
+				id: {
+					allowNull: false,
+					autoIncrement: true,
+					primaryKey: true,
+					type: DataTypes.INTEGER,
+				},
+				pollName: {
+					type: DataTypes.STRING(100),
+				},
+				pollType: {
+					type: DataTypes.STRING(10),
+				},
+				selectionType: {
+					type: DataTypes.STRING(10),
+				},
+				allowDuplication: {
+					type: DataTypes.BOOLEAN,
+				},
+				state: {
+					type: DataTypes.STRING(10),
+				},
+				pollDate: {
+					type: DataTypes.DATE,
+				},
+				createdAt: {
+					allowNull: false,
+					type: DataTypes.DATE,
+				},
+				updatedAt: {
+					allowNull: false,
+					type: DataTypes.DATE,
+				},
+			},
+			{sequelize, tableName: "Polls"},
+		);
+	}
+
+	static associate(models) {
+		models.Poll.belongsTo(models.Event);
+		models.Poll.hasMany(models.Candidate);
+	}
+}

--- a/backend/DB/models/question.js
+++ b/backend/DB/models/question.js
@@ -1,49 +1,51 @@
-module.exports = (sequelize, DataTypes) => {
-	const Question = sequelize.define(
-		"Question",
-		{
-			id: {
-				allowNull: false,
-				autoIncrement: true,
-				primaryKey: true,
-				type: DataTypes.INTEGER,
-			},
-			content: {
-				type: DataTypes.STRING(500),
-				defaultValue: "",
-			},
-			state: {
-				type: DataTypes.STRING(20),
-				allowNull: false,
-			},
-			createdAt: {
-				allowNull: false,
-				type: DataTypes.DATE,
-			},
-			isStared: {
-				type: DataTypes.BOOLEAN,
-				defaultValue: false,
-			},
-			updatedAt: {
-				allowNull: false,
-				type: DataTypes.DATE,
-			},
-			likeCount: {
-				allowNull: false,
-				type: DataTypes.INTEGER,
-				defaultValue: 0,
-			},
-		},
-		{},
-	);
+import {Model} from "sequelize";
 
-	Question.associate = function(models) {
-		Question.belongsTo(models.Event);
-		Question.belongsTo(models.Guest);
-		Question.hasMany(models.Question);
-		Question.hasMany(models.Like);
-		Question.hasMany(models.Emoji);
-		Question.belongsTo(models.Question);
-	};
-	return Question;
-};
+export default class Question extends Model {
+	static init(sequelize, DataTypes) {
+		return super.init(
+			{
+				id: {
+					allowNull: false,
+					autoIncrement: true,
+					primaryKey: true,
+					type: DataTypes.INTEGER,
+				},
+				content: {
+					type: DataTypes.STRING(500),
+					defaultValue: "",
+				},
+				state: {
+					type: DataTypes.STRING(20),
+					allowNull: false,
+				},
+				createdAt: {
+					allowNull: false,
+					type: DataTypes.DATE,
+				},
+				isStared: {
+					type: DataTypes.BOOLEAN,
+					defaultValue: false,
+				},
+				updatedAt: {
+					allowNull: false,
+					type: DataTypes.DATE,
+				},
+				likeCount: {
+					allowNull: false,
+					type: DataTypes.INTEGER,
+					defaultValue: 0,
+				},
+			},
+			{sequelize, tableName: "Questions"},
+		);
+	}
+
+	static associate(models) {
+		models.Question.belongsTo(models.Event);
+		models.Question.belongsTo(models.Guest);
+		models.Question.hasMany(models.Question);
+		models.Question.hasMany(models.Like);
+		models.Question.hasMany(models.Emoji);
+		models.Question.belongsTo(models.Question);
+	}
+}

--- a/backend/DB/models/vote.js
+++ b/backend/DB/models/vote.js
@@ -1,28 +1,30 @@
-module.exports = (sequelize, DataTypes) => {
-	const Vote = sequelize.define(
-		"Vote",
-		{
-			id: {
-				allowNull: false,
-				autoIncrement: true,
-				primaryKey: true,
-				type: DataTypes.INTEGER,
-			},
-			createdAt: {
-				allowNull: false,
-				type: DataTypes.DATE,
-			},
-			updatedAt: {
-				allowNull: false,
-				type: DataTypes.DATE,
-			},
-		},
-		{},
-	);
+import {Model} from "sequelize";
 
-	Vote.associate = function(models) {
-		Vote.belongsTo(models.Guest);
-		Vote.belongsTo(models.Candidate);
-	};
-	return Vote;
-};
+export default class Vote extends Model {
+	static init(sequelize, DataTypes) {
+		return super.init(
+			{
+				id: {
+					allowNull: false,
+					autoIncrement: true,
+					primaryKey: true,
+					type: DataTypes.INTEGER,
+				},
+				createdAt: {
+					allowNull: false,
+					type: DataTypes.DATE,
+				},
+				updatedAt: {
+					allowNull: false,
+					type: DataTypes.DATE,
+				},
+			},
+			{sequelize, tableName: "Votes"},
+		);
+	}
+
+	static associate(models) {
+		models.Vote.belongsTo(models.Guest);
+		models.Vote.belongsTo(models.Candidate);
+	}
+}


### PR DESCRIPTION
* 기존 sequelize migration 이 기본으로 제공하는 model define 방식은 함수를 이용 및 모델을 동적으로 로드하기때문에 타입 추론 불가.
* js 의 ES6 이상에서 지원하는 Class를 이용하여 모델을 정의하고, 정적로드 방식으로 변경시,  sequelize model을 IDE 상에서 타입추론 및 자동완성 기능을 사용 가능
* 정의한 sequelize 모델을 사용할때는 이전과 동일하게 사용가능.

아래 링크를 참고
[https://codewithhugo.com/using-es6-classes-for-sequelize-4-models/](https://codewithhugo.com/using-es6-classes-for-sequelize-4-models/)
